### PR TITLE
Sl/steady state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 sudo: false
 os:
   - linux
-  - osx
+  # - osx  # we don't do any binary dependencies or OS specific magic
 julia:
   - release
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 MacroTools
 YAML
 DataStructures
+NLsolve

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -6,7 +6,11 @@ using YAML: load_file
 using NLsolve
 
 export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
-       AbstractDoloFunctor, SymbolicModel, DTCSCCModel, DTMSCCModel
+       AbstractDoloFunctor, SymbolicModel, DTCSCCModel, DTMSCCModel,
+       ModelCalibration,
+
+       # functions
+       eval_with, evaluate, evaluate!
 
 # set up core types
 abstract AbstractModel
@@ -30,6 +34,6 @@ include("util.jl")
 include("parser.jl")
 include("model_types.jl")
 
-include("algos/util.jl")
+include("algos/dtcscc.jl")
 
 end # module

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -3,6 +3,7 @@ module Dolo
 using MacroTools
 using DataStructures: OrderedDict
 using YAML: load_file
+using NLsolve
 
 export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
        AbstractDoloFunctor, SymbolicModel, DTCSCCModel, DTMSCCModel
@@ -29,5 +30,6 @@ include("util.jl")
 include("parser.jl")
 include("model_types.jl")
 
+include("algos/util.jl")
 
 end # module

--- a/src/algos/dtcscc.jl
+++ b/src/algos/dtcscc.jl
@@ -24,7 +24,7 @@ function solve_steady_state(m::DTCSCCModel, mc::ModelCalibration=m.calibration)
 
     # otherwise set controls
     out = deepcopy(mc)
-    out[m.symbolic.symbols[:states]...] = sol.zero[1:ns]
-    out[m.symbolic.symbols[:controls]...] = sol.zero[ns+1:end]
+    out["states"] = sol.zero[1:ns]
+    out["controls"] = sol.zero[ns+1:end]
     out
 end

--- a/src/algos/dtcscc.jl
+++ b/src/algos/dtcscc.jl
@@ -1,0 +1,29 @@
+function solve_steady_state(m::DTCSCCModel, mc::ModelCalibration=m.calibration)
+    p, s0, x0 = mc["parameters", "states", "controls"]
+    e = zeros(mc["shocks"])
+    ns = length(s)
+    nx = length(x)
+
+    function obj!(sx, out)
+        s = sub(sx, 1:ns)
+        X = sub(sx, ns+1:ns+nx)
+        x_out = sub(out, ns+1:ns+nx)
+
+        # update state part of residual
+        S = evaluate(m.functions.transition, s, x, e, p)
+        out[1:ns] = S-s
+
+        # now update control part
+        evaluate!(m.functions.arbitrage, s, x, e, S, X, p, x_out)
+        out
+    end
+
+    sol = nlsolve(obj!, vcat(s0, x0))
+    !converged(sol) &&  error("Nonlinear solver failed to find steady state")
+
+    # otherwise set controls
+    out = deepcopy(mc)
+    out[m.symbolic.symbols[:states]...] = sol.zero[1:ns]
+    out[m.symbolic.symbols[:controls]...] = sol.zero[ns+1:end]
+    out
+end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -174,8 +174,15 @@ end
 _replace_me(mc::ModelCalibration, s::Symbol) = get(mc.flat, s, s)
 _replace_me(mc, o) = o
 
-eval_with(mc::ModelCalibration, ex::Expr) =
-    eval(MacroTools.prewalk(s->_replace_me(mc, s), ex))
+function eval_with(mc::ModelCalibration, ex::Expr)
+    # put in let block to allow us to define intermediates in expr and not
+    # have them become globals in `current_module()` at callsite
+    new_ex = MacroTools.prewalk(s->_replace_me(mc, s), ex)
+    eval(:(
+    let
+        $new_ex
+    end))
+end
 
 eval_with(mc::ModelCalibration, s::AbstractString) = eval_with(mc, parse(s))
 

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -237,14 +237,14 @@ for (TF, TM, ms) in [(:DTCSCCfunctions, :DTCSCCModel, :(:dtcscc)),
         model_spec(::Type{$(TF)}) = $ms
 
         # function type constructor
-        function $(TF)(sm::SymbolicModel)
+        function $(TF)(sm::SymbolicModel; print_code::Bool=false)
             if model_spec(sm) != model_spec($TF)
                 msg = string("Symbolic model is of type $(model_spec(sm)) ",
                              "cannot create functions of type $($TF)")
                 error(msg)
             end
             $(TF)([let
-                       eval(compile_equation(sm, fld))
+                       eval(compile_equation(sm, fld; print_code=print_code))
                    end
                    for fld in fieldnames($(TF))]...)
         end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -109,6 +109,7 @@ immutable ModelCalibration
     flat::OrderedDict{Symbol,Float64}
     grouped::Dict{Symbol,Vector{Float64}}
     symbol_table::Dict{Symbol,Tuple{Symbol,Int}}
+    symbol_groups::OrderedDict{Symbol,Vector{Symbol}}
 end
 
 function ModelCalibration(sm::SymbolicModel)
@@ -125,14 +126,16 @@ function ModelCalibration(sm::SymbolicModel)
         end
     end
 
+    # make sure we documented where in grouped every symbol is
     @assert sort(collect(keys(symbol_table))) == sort(collect(keys(flat)))
 
-    ModelCalibration(flat, grouped, symbol_table)
+    ModelCalibration(flat, grouped, symbol_table, deepcopy(sm.symbols))
 end
 
 for f in (:copy, :deepcopy)
     @eval Base.$(f)(mc::ModelCalibration) =
-        ModelCalibration($(f)(mc.flat), $(f)(mc.grouped), $(f)(mc.symbol_table))
+        ModelCalibration($(f)(mc.flat), $(f)(mc.grouped),
+                         $(f)(mc.symbol_table), $(f)(mc.symbol_groups))
 end
 
 # TODO: Decide if we should keep these semantics. Right now I've implemented
@@ -144,8 +147,10 @@ Base.getindex(mc::ModelCalibration, n::Symbol) = mc.flat[n]
 Base.getindex(mc::ModelCalibration, n::AbstractString) = mc.grouped[symbol(n)]
 
 # now define methods that let us extract multiple params or groups at a time
-Base.getindex(mc::ModelCalibration, n1::Symbol, nms::Symbol...) =
-    [mc[n] for n in vcat(n1, nms...)]
+Base.getindex(mc::ModelCalibration, nms::Symbol...) = [mc[n] for n in nms]
+
+# define this one with n1, nms... to avoid method ambiguity with previous
+# method above that has just nms::Symbol...
 Base.getindex(mc::ModelCalibration, n1::AbstractString, nms::AbstractString...) =
     Vector{Float64}[mc[n] for n in vcat(n1, nms...)]
 
@@ -161,13 +166,30 @@ end
 
 # setting multiple values
 function Base.setindex!(mc::ModelCalibration, vs::AbstractVector, ks::Symbol...)
-    length(vs) == length(ks) ||
+    if length(vs) != length(ks)
+        error("length of keys and values must be the same")
+    end
+
     for (v, k) in zip(vs, ks)
         mc[k] = v
     end
     mc
 end
 
+# setting a single group
+function Base.setindex!(mc::ModelCalibration, v::AbstractVector, k::AbstractString)
+    ks = mc.symbol_groups[symbol(k)]
+    if length(v) != length(ks)
+        msg = string("Calibration has $(length(ks)) symbols in $k, ",
+                     "but passed $(length(v)) values")
+        error(msg)
+    end
+
+    for (v, k) in zip(v, ks)
+        mc[k] = v
+    end
+    mc
+end
 
 # tries to replace a symbol if the key is in the calibration, otherwise just
 # keeps the symbol in place

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -110,7 +110,7 @@ function _main_body_block(sm::ASM, targets::Vector{Symbol}, exprs::Vector{Expr})
     func_block = Expr(:block, assignments...)
 end
 
-function compile_equation(sm::ASM, func_nm::Symbol)
+function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
     # extract spec from recipe
     spec = RECIPES[model_spec(sm)][:specs][func_nm]
 
@@ -190,6 +190,8 @@ function compile_equation(sm::ASM, func_nm::Symbol)
         $tnm()
         # TODO: can we use broadcast! to get pretty far towards guvectorize?
     end
+
+    print_code && println(code)
 
     code
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -127,7 +127,11 @@ function compile_equation(sm::ASM, func_nm::Symbol)
         code = quote
             immutable $tnm <: AbstractDoloFunctor
             end
-            function Base.call(::$tnm, args...)
+            function evaluate(::$tnm, args...)
+                error($msg)
+            end
+
+            function evaluate!(::$tnm, args...)
                 error($msg)
             end
 

--- a/test/model_types.jl
+++ b/test/model_types.jl
@@ -2,13 +2,17 @@
 
     @testset "ModelCalibration" begin
         function new_mc()
-            flat = OrderedDict{Symbol,Float64}(:k=>8.5, :i=>1.1)
-            grouped = Dict{Symbol,Vector{Float64}}(:states=>[8.5],
+            flat = OrderedDict{Symbol,Float64}(:k=>8.5, :z=>0.5, :i=>1.1)
+            grouped = Dict{Symbol,Vector{Float64}}(:states=>[8.5, 0.5],
                                                    :controls=>[1.1])
             symbol_table = OrderedDict{Symbol,Tuple{Symbol,Int}}()
             symbol_table[:k] = (:states, 1)
+            symbol_table[:z] = (:states, 2)
             symbol_table[:i] = (:controls, 1)
-            mc = ModelCalibration(flat, grouped, symbol_table)
+            symbol_groups = OrderedDict{Symbol,Vector{Symbol}}()
+            symbol_groups[:states] = [:k, :z]
+            symbol_groups[:controls] = [:i]
+            mc = ModelCalibration(flat, grouped, symbol_table, symbol_groups)
         end
         mc = new_mc()
         mc2 = copy(mc)  # shallow copy. underlying arrays are same
@@ -26,32 +30,42 @@
             # getindex
             @test 8.5 == mc[:k] == @inferred getindex(mc, :k)
             @test 8.5 == mc.flat[:k] == @inferred getindex(mc.flat, :k)
-            @test [8.5] == mc["states"] == @inferred getindex(mc, "states")
-            @test [8.5] == mc.grouped[:states] == @inferred getindex(mc.grouped, :states)
+            @test [8.5, 0.5] == mc["states"] == @inferred getindex(mc, "states")
+            @test [8.5, 0.5] == mc.grouped[:states] == @inferred getindex(mc.grouped, :states)
 
             # setindex!. Do this on mc3 so as not to change mc. Verify that
             # arrays in mc are unchanged after this
             mc3[:k] = 5.0
 
             @test mc3[:k] == 5.0
-            @test mc3["states"] == [5.0]
+            @test mc3["states"] == [5.0, 0.5]
             @test mc[:k] == 8.5
-            @test mc["states"] == [8.5]
+            @test mc["states"] == [8.5, 0.5]
 
             # try same with mc2 and show that mc[:k] is unchanged,
             # but mc["states"] is
             mc2[:k] = 5.0
             @test mc2[:k] == 5.0
-            @test mc2["states"] == [5.0]
+            @test mc2["states"] == [5.0, 0.5]
             @test mc[:k] == 8.5
-            @test mc["states"] == [5.0]
+            @test mc["states"] == [5.0, 0.5]
+
+            # make sure we throw if setindex! doesn't have matching sizes
+            @test_throws ErrorException setindex!(mc3, rand(4), :k, :i, :z)
 
             # now get back our original mc
             mc = new_mc()
 
             # test vector version
             @test [8.5, 1.1] == @inferred getindex(mc, :k, :i)
-            @test Vector{Float64}[[8.5], [1.1]] == @inferred getindex(mc, "states", "controls")
+            @test Vector{Float64}[[8.5, 0.5], [1.1]] == @inferred getindex(mc, "states", "controls")
+
+            # test setindex! for a group
+            mc3["states"] = [42.0, 43.0]
+            @test [42.0, 43.0] == @inferred getindex(mc3, "states")
+            @test 42.0 == mc3[:k]
+            @test 43.0 == mc3[:z]
+            @test_throws ErrorException setindex!(mc3, rand(3), "states")
         end
 
         @testset "eval_with" begin

--- a/test/model_types.jl
+++ b/test/model_types.jl
@@ -1,0 +1,80 @@
+@testset "testing model_types" begin
+
+    @testset "ModelCalibration" begin
+        function new_mc()
+            flat = OrderedDict{Symbol,Float64}(:k=>8.5, :i=>1.1)
+            grouped = Dict{Symbol,Vector{Float64}}(:states=>[8.5],
+                                                   :controls=>[1.1])
+            symbol_table = OrderedDict{Symbol,Tuple{Symbol,Int}}()
+            symbol_table[:k] = (:states, 1)
+            symbol_table[:i] = (:controls, 1)
+            mc = ModelCalibration(flat, grouped, symbol_table)
+        end
+        mc = new_mc()
+        mc2 = copy(mc)  # shallow copy. underlying arrays are same
+        mc3 = deepcopy(mc)  # deep copy. underlying arrays are different
+
+        @testset "copy/deepcopy" begin
+
+            # triple = effectively checks if two arrays point to same memory
+            # address
+            @test mc2.grouped[:states] === mc.grouped[:states]
+            @test !(mc3.grouped[:states] === mc.grouped[:states])
+        end
+
+        @testset "getindex/setindex!" begin
+            # getindex
+            @test 8.5 == mc[:k] == @inferred getindex(mc, :k)
+            @test 8.5 == mc.flat[:k] == @inferred getindex(mc.flat, :k)
+            @test [8.5] == mc["states"] == @inferred getindex(mc, "states")
+            @test [8.5] == mc.grouped[:states] == @inferred getindex(mc.grouped, :states)
+
+            # setindex!. Do this on mc3 so as not to change mc. Verify that
+            # arrays in mc are unchanged after this
+            mc3[:k] = 5.0
+
+            @test mc3[:k] == 5.0
+            @test mc3["states"] == [5.0]
+            @test mc[:k] == 8.5
+            @test mc["states"] == [8.5]
+
+            # try same with mc2 and show that mc[:k] is unchanged,
+            # but mc["states"] is
+            mc2[:k] = 5.0
+            @test mc2[:k] == 5.0
+            @test mc2["states"] == [5.0]
+            @test mc[:k] == 8.5
+            @test mc["states"] == [5.0]
+
+            # now get back our original mc
+            mc = new_mc()
+
+            # test vector version
+            @test [8.5, 1.1] == @inferred getindex(mc, :k, :i)
+            @test Vector{Float64}[[8.5], [1.1]] == @inferred getindex(mc, "states", "controls")
+        end
+
+        @testset "eval_with" begin
+            # test _replace_me
+            @test Dolo._replace_me(mc, :(+)) == :(+)
+            @test Dolo._replace_me(mc, :(bing)) == :(bing)
+            @test Dolo._replace_me(mc, 100) == 100
+            @test Dolo._replace_me(mc, :k) == 8.5
+
+            @test eval_with(mc, "k+1") == 9.5
+            @test eval_with(mc, "k+i") == 9.6
+
+            # test expression version
+            @test eval_with(mc, :(k+i)) == 9.6
+
+            # test that we can define temporaries that aren't created in this
+            # scope
+            @test 9.6 == eval_with(mc, quote
+                foobar = k
+                foobar + i
+                end)
+            @test !isdefined(current_module(), :foobar)
+
+        end
+    end
+end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -199,7 +199,7 @@ Dolo.model_spec(::MockSymbolic) = :dtcscc
         obj1 = let
             eval(Dolo.compile_equation(sm, :value))
         end
-        @test_throws ErrorException obj1()
+        @test_throws ErrorException evaluate(obj1)
         @test @compat(supertype)(typeof(obj1)) == Dolo.AbstractDoloFunctor
 
         obj2 = let
@@ -225,15 +225,15 @@ Dolo.model_spec(::MockSymbolic) = :dtcscc
         want = [y, c, rk, w]
         out = zeros(4)
 
-        @test_throws MethodError obj2()
-        @test_throws MethodError obj2(s)
-        @test_throws MethodError obj2(s, x)
+        @test_throws MethodError evaluate(obj2, )
+        @test_throws MethodError evaluate(obj2, s)
+        @test_throws MethodError evaluate(obj2, s, x)
 
         # test allocating version
-        @test @inferred(obj2(s, x, p)) == want
+        @test @inferred(evaluate(obj2, s, x, p)) == want
 
         # test non-allocating version
-        @inferred obj2(s, x, p, out)
+        @inferred evaluate!(obj2, s, x, p, out)
         @test out == want
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Dolo
 using Compat
+using DataStructures
 
 # write your own tests here
 if VERSION >= v"0.5-"
@@ -11,3 +12,4 @@ end
 
 include("parser.jl")
 include("util.jl")
+include("model_types.jl")


### PR DESCRIPTION
This PR does a few things:

Adds `setindex!(::ModelCalibration, ...)` methods.

- - - 

Adds fields `symbol_table` and `symbol_groups` to `ModelCalibration`. 

`symbol_table` is a `Dict{Symbol,Tuple{Symbol,Int}}` where each key is a symbol name and each value is a tuple of the form `(group_name::Symbol, index_in_group::Int)`. This allows us to easily update `grouped` after `flat` is updated.

`symbol_groups` is a `OrderedDict{Symbol,Vector{Symbol}}` where keys are symbol groups and values are vectors of symbols that belong to that group. When you construct a `ModelCalibration` from `sm::SymbolicModel`, this will simply be a deep copy of `sm.symbols`. 

- - -

makes the call to `eval` inside `eval_with` happen in a `let` block so expressions can contain temporary variables that don't become globals.

- - - 

Added tests for ModelCalibration construction, `getindex`, `setindex!`, and `eval_with` methods.

- - -

Added very basic routine to compute the deterministic steady state of a `dtcscc` model.

## Some other comments

There is some redundancy in the fields of `ModelCalibration`. We could get away with having just two fields: one that holds numerical values for symbols and the other that connects symbols to groups. 

I chose to have all 4 for now because it is fairly costless to keep them around and it makes the `getindex` and `setindex!` operations easier to implement and reason about.

If anyone can make a good argument for dropping one or more of them, I'd be happy to hear it out. I'm not 100% satisfied with the duplication of the data, but it does make the type easier to work with.

