### PR TITLE
Sl/calib

### DIFF
--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -7,7 +7,7 @@ using NLsolve
 
 export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
        AbstractDoloFunctor, SymbolicModel, DTCSCCModel, DTMSCCModel,
-       ModelCalibration,
+       FlatCalibration, GroupedCalibration, ModelCalibration,
 
        # functions
        eval_with, evaluate, evaluate!

--- a/src/algos/dtcscc.jl
+++ b/src/algos/dtcscc.jl
@@ -1,6 +1,6 @@
 function solve_steady_state(m::DTCSCCModel, mc::ModelCalibration=m.calibration)
-    p, s0, x0 = mc["parameters", "states", "controls"]
-    e_ = zeros(mc["shocks"])
+    p, s0, x0 = mc[:parameters, :states, :controls]
+    e_ = zeros(mc[:shocks])
     ns = length(s0)
     nx = length(x0)
 
@@ -24,7 +24,7 @@ function solve_steady_state(m::DTCSCCModel, mc::ModelCalibration=m.calibration)
 
     # otherwise set controls
     out = deepcopy(mc)
-    out["states"] = sol.zero[1:ns]
-    out["controls"] = sol.zero[ns+1:end]
+    out[:states] = sol.zero[1:ns]
+    out[:controls] = sol.zero[ns+1:end]
     out
 end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -103,20 +103,113 @@ model_spec(sm::SymbolicModel) = sm.model_type
 # Calibration #
 # ----------- #
 
-# wrapper around ordered dict that will allow us to implement our own
-# getindex/setindex! methods
+immutable FlatCalibration <: Associative{Symbol,Float64}
+    d::OrderedDict{Symbol,Float64}
+end
+
+FlatCalibration(pairs::Pair{Symbol,Float64}...) =
+    FlatCalibration(OrderedDict(pairs))
+
+FlatCalibration() = FlatCalibration(OrderedDict{Symbol,Float64}())
+
+immutable GroupedCalibration <: Associative{Symbol,Vector{Float64}}
+    d::Dict{Symbol,Vector{Float64}}
+end
+
+GroupedCalibration() = GroupedCalibration(Dict{Symbol,Vector{Float64}}())
+
+GroupedCalibration(pairs::Pair{Symbol,Vector{Float64}}...) =
+    GroupedCalibration(Dict(pairs))
+
+# use let block so `Calib` isn't a member of the Dolo module
+let
+    typealias Calib Union{FlatCalibration,GroupedCalibration}
+
+    Base.getindex(c::Calib, n::Symbol) = c.d[n]
+    Base.getindex(c::Calib, nms::Symbol...) = [c[n] for n in nms]
+
+    # define the rest of the Associative interface by forwarding to c.d
+
+    # 1-arg functions
+    for f in [:length, :keys, :values, :keytype, :valtype, :eltype, :isempty,
+              :start]
+        @eval Base.$(f)(c::$(Calib)) = $(f)(c.d)
+    end
+
+    # 2-arg functions
+    for f in [:haskey, :delete!, :pop!, :sizehint!, :next, :done]
+        @eval Base.$(f)(c::$(Calib), arg) = $(f)(c.d, arg)
+    end
+
+    # 3-arg functions
+    for f in [:get, :get!, :getkey, :pop!]
+        @eval Base.$(f)(c::$(Calib), arg1, arg2) = $(f)(c.d, arg1, arg2)
+    end
+
+    # methods that didn't match signatures above
+    Base.get!(f::Function, c::Calib, key) = get!(f, c.d, key)
+    Base.get(f::Function, c::Calib, key) = get(f, c.d, key)
+    Base.merge!{T<:Calib}(c::T, others::T...) =
+        T(merge!(c.d, [o.d for o in others]...))
+    Base.show(io::IO, c::Calib) = show(io, c.d)
+    Base.showdict(io::IO, c::Calib) = Base.showdict(io, c.d)
+    Base.copy{T<:Calib}(c::T) = T(copy(c.d))
+    Base.deepcopy{T<:Calib}(c::T) = T(deepcopy(c.d))
+end
+
+# setting a single value
+Base.setindex!(fc::FlatCalibration, v::Real, k::Symbol) =
+    fc.d[k] = convert(Float64, v)
+
+# setting multiple values
+function Base.setindex!(fc::FlatCalibration, vs::Union{Tuple,AbstractVector},
+                        ks::Symbol...)
+    if length(vs) != length(ks)
+        throw(DimensionMismatch("length of keys and values must be the same"))
+    end
+
+    for (v, k) in zip(vs, ks)
+        fc[k] = v
+    end
+    fc
+end
+
+# setting a single group
+function Base.setindex!(gc::GroupedCalibration, v::AbstractVector, k::Symbol)
+    # use get with default of v in case we are adding a new key
+    if length(v) != length(get(gc, k, v))
+        msg = string("length $(length(v)) of new values for key $k does",
+                     "not match length of existing value ($(length(gc[k])))")
+        throw(DimensionMismatch(msg))
+    end
+    gc.d[k] = convert(Vector{Float64}, v)
+end
+
+# setting multiple groups
+function Base.setindex!(gc::GroupedCalibration, vs::Tuple, ks::Symbol...)
+    if length(vs) != length(ks)
+        throw(DimensionMismatch("length of keys and values must be the same"))
+    end
+
+    for (v, k) in zip(vs, ks)
+        gc[k] = v
+    end
+    gc
+end
+
+# Contains a FlatCalibration and GroupedCalibration, plus information on symbols
 immutable ModelCalibration
-    flat::OrderedDict{Symbol,Float64}
-    grouped::Dict{Symbol,Vector{Float64}}
+    flat::FlatCalibration
+    grouped::GroupedCalibration
     symbol_table::Dict{Symbol,Tuple{Symbol,Int}}
     symbol_groups::OrderedDict{Symbol,Vector{Symbol}}
 end
 
 function ModelCalibration(sm::SymbolicModel)
-    flat = solve_triangular_system(sm)
-    grouped = Dict{Symbol,Vector{Float64}}()
+    flat = FlatCalibration(solve_triangular_system(sm))
+    grouped = GroupedCalibration()
     for (k, nms) in sm.symbols
-        grouped[k] = [flat[nm] for nm in nms]
+        grouped[k] = Float64[flat[nm] for nm in nms]
     end
 
     symbol_table = Dict{Symbol,Tuple{Symbol,Int}}()
@@ -138,54 +231,34 @@ for f in (:copy, :deepcopy)
                          $(f)(mc.symbol_table), $(f)(mc.symbol_groups))
 end
 
-# TODO: Decide if we should keep these semantics. Right now I've implemented
-#       it so that if we do mc[x::Symbol] we try to extract the calibrated
-#       value for a single parameter as a Float64. Then if we call
-#       mc[s::AbstractString] we try to extract a whole symbol group as a
-#       Vector{Float64}
-Base.getindex(mc::ModelCalibration, n::Symbol) = mc.flat[n]
-Base.getindex(mc::ModelCalibration, n::AbstractString) = mc.grouped[symbol(n)]
-
-# now define methods that let us extract multiple params or groups at a time
+# getindex and setindex! should be forwarded on to the grouped field
+Base.getindex(mc::ModelCalibration, n::Symbol) = mc.grouped[n]
 Base.getindex(mc::ModelCalibration, nms::Symbol...) = [mc[n] for n in nms]
 
-# define this one with n1, nms... to avoid method ambiguity with previous
-# method above that has just nms::Symbol...
-Base.getindex(mc::ModelCalibration, n1::AbstractString, nms::AbstractString...) =
-    Vector{Float64}[mc[n] for n in vcat(n1, nms...)]
-
-# setting a single value
-function Base.setindex!(mc::ModelCalibration, v::Real, k::Symbol)
-    # update in flat
-    mc.flat[k] = convert(Float64, v)
-
-    # update in grouped
-    grp, ix = mc.symbol_table[k]
-    mc.grouped[grp][ix] = v
-end
-
-# setting multiple values
-function Base.setindex!(mc::ModelCalibration, vs::AbstractVector, ks::Symbol...)
-    if length(vs) != length(ks)
-        error("length of keys and values must be the same")
+function Base.setindex!(mc::ModelCalibration, v::AbstractVector, k::Symbol)
+    ks = mc.symbol_groups[k]
+    if length(v) != length(ks)
+        msg = string("Calibration has $(length(ks)) symbols in $k, ",
+                     "but passed $(length(v)) values")
+        throw(DimensionMismatch(msg))
     end
 
-    for (v, k) in zip(vs, ks)
-        mc[k] = v
+    # update grouped
+    mc.grouped[k] = v
+
+    # update flat
+    for (vi, ki) in zip(v, ks)
+        mc.flat[ki] = vi
     end
     mc
 end
 
-# setting a single group
-function Base.setindex!(mc::ModelCalibration, v::AbstractVector, k::AbstractString)
-    ks = mc.symbol_groups[symbol(k)]
-    if length(v) != length(ks)
-        msg = string("Calibration has $(length(ks)) symbols in $k, ",
-                     "but passed $(length(v)) values")
-        error(msg)
+function Base.setindex!(mc::ModelCalibration, vs::Tuple, ks::Symbol...)
+    if length(vs) != length(ks)
+        throw(DimensionMismatch("length of keys and values must be the same"))
     end
 
-    for (v, k) in zip(v, ks)
+    for (k, v) in zip(ks, vs)
         mc[k] = v
     end
     mc

--- a/test/model_types.jl
+++ b/test/model_types.jl
@@ -106,6 +106,29 @@
             @test [8.5, 0.5] == @inferred getindex(mc, :states)
             @test Vector{Float64}[[8.5, 0.5], [1.1]] == @inferred getindex(mc, :states, :controls)
 
+            # setindex!. Do this on mc3 so as not to change mc. Verify that
+            # arrays in mc are unchanged after this
+            mc3[:k] = 5.0
+
+            @test mc3.flat[:k] == 5.0
+            @test mc3[:states] == [5.0, 0.5]
+            @test mc.flat[:k] == 8.5
+            @test mc[:states] == [8.5, 0.5]
+
+            # try same with mc2 and show that mc[:k] is unchanged,
+            # but mc["states"] is
+            mc2[:k] = 5.0
+            @test mc2.flat[:k] == 5.0
+            @test mc2[:states] == [5.0, 0.5]
+            @test mc.flat[:k] == 8.5
+            @test mc[:states] == [5.0, 0.5]
+
+            # make sure we throw if setindex! doesn't have matching sizes
+            @test_throws DimensionMismatch setindex!(mc3, (1,2,3,4), :k, :i, :z)
+
+            # now get back our original mc
+            mc = new_mc()
+
             # test setindex! for a group
             mc3[:states] = [42.0, 43.0]
             @test [42.0, 43.0] == @inferred getindex(mc3, :states)

--- a/test/model_types.jl
+++ b/test/model_types.jl
@@ -2,8 +2,8 @@
 
     @testset "ModelCalibration" begin
         function new_mc()
-            flat = OrderedDict{Symbol,Float64}(:k=>8.5, :z=>0.5, :i=>1.1)
-            grouped = Dict{Symbol,Vector{Float64}}(:states=>[8.5, 0.5],
+            flat = FlatCalibration(:k=>8.5, :z=>0.5, :i=>1.1)
+            grouped = GroupedCalibration(:states=>[8.5, 0.5],
                                                    :controls=>[1.1])
             symbol_table = OrderedDict{Symbol,Tuple{Symbol,Int}}()
             symbol_table[:k] = (:states, 1)
@@ -18,6 +18,81 @@
         mc2 = copy(mc)  # shallow copy. underlying arrays are same
         mc3 = deepcopy(mc)  # deep copy. underlying arrays are different
 
+        @testset "FlatCalibration" begin
+            d = OrderedDict(:x=>1.0, :y=>2.0)
+
+            # test constructors
+            fc1 = FlatCalibration(d)
+            fc2 = FlatCalibration(:x=>1.0, :y=>2.0)
+            @test fc1 == fc2
+            @test !(fc1 === fc2)
+
+            # getindex
+            @test 1.0 == @inferred getindex(fc1, :x)
+            @test [1.0, 2.0] == @inferred getindex(fc1, :x, :y)
+
+            # setindex
+            fc1[:z] = 1.0
+            @test fc1[:z] == 1.0
+
+            # conversion to Float64
+            for T in (Float16, Float32, Float64, Int8, Int16, Int32, Int64,
+                      Rational{Int}, BigFloat, BigInt)
+                fc1[:q] = one(T)
+                @test Float64(1.0) == @inferred getindex(fc1, :q)
+            end
+
+            # multiple values from tuple
+            fc1[:a, :b, :c] = 4, 5, 6
+            @test 4.0 == @inferred getindex(fc1, :a)
+            @test 5.0 == @inferred getindex(fc1, :b)
+            @test 6.0 == @inferred getindex(fc1, :c)
+            @test_throws DimensionMismatch setindex!(fc1, (4, 5), :a, :b, :c)
+
+            # multiple values from (poorly typed) Vector
+            fc1[:a, :b, :c] = Any[7, 8, 9]
+            @test 7.0 == @inferred getindex(fc1, :a)
+            @test 8.0 == @inferred getindex(fc1, :b)
+            @test 9.0 == @inferred getindex(fc1, :c)
+            @test_throws DimensionMismatch setindex!(fc1, [7, 8], :a, :b, :c)
+        end
+
+        @testset "GroupedCalibration" begin
+            d = Dict(:x=>[1.0, 2.0], :y=>[2.0, 3.0])
+
+            # test constructors
+            gc1 = GroupedCalibration(d)
+            gc2 = GroupedCalibration(:x=>[1.0, 2.0], :y=>[2.0, 3.0])
+            @test gc1 == gc2
+            @test !(gc1 === gc2)
+
+            # getindex
+            @test [1.0, 2.0] == @inferred getindex(gc1, :x)
+            @test Vector{Float64}[[1.0, 2.0], [2.0, 3.0]] == @inferred getindex(gc1, :x, :y)
+
+            # setindex
+            gc1[:z] = [1.0]
+            @test gc1[:z] == [1.0]
+
+            # existing x has length 2, this is only length 1
+            @test_throws DimensionMismatch setindex!(gc1, [1.0], :x)
+
+            # conversion to Float64
+            for T in (Float16, Float32, Float64, Int8, Int16, Int32, Int64,
+                      Rational{Int}, BigFloat, BigInt)
+                gc1[:q] = [one(T)]
+                @test [Float64(1.0)] == @inferred getindex(gc1, :q)
+            end
+
+            # multiple values from tuple
+            gc1[:a, :b, :c] = [4], [5], [6]
+            @test [4.0] == @inferred getindex(gc1, :a)
+            @test [5.0] == @inferred getindex(gc1, :b)
+            @test [6.0] == @inferred getindex(gc1, :c)
+            @test_throws DimensionMismatch setindex!(gc1, ([4], [5]), :a, :b, :c)
+
+        end
+
         @testset "copy/deepcopy" begin
 
             # triple = effectively checks if two arrays point to same memory
@@ -28,44 +103,25 @@
 
         @testset "getindex/setindex!" begin
             # getindex
-            @test 8.5 == mc[:k] == @inferred getindex(mc, :k)
-            @test 8.5 == mc.flat[:k] == @inferred getindex(mc.flat, :k)
-            @test [8.5, 0.5] == mc["states"] == @inferred getindex(mc, "states")
-            @test [8.5, 0.5] == mc.grouped[:states] == @inferred getindex(mc.grouped, :states)
-
-            # setindex!. Do this on mc3 so as not to change mc. Verify that
-            # arrays in mc are unchanged after this
-            mc3[:k] = 5.0
-
-            @test mc3[:k] == 5.0
-            @test mc3["states"] == [5.0, 0.5]
-            @test mc[:k] == 8.5
-            @test mc["states"] == [8.5, 0.5]
-
-            # try same with mc2 and show that mc[:k] is unchanged,
-            # but mc["states"] is
-            mc2[:k] = 5.0
-            @test mc2[:k] == 5.0
-            @test mc2["states"] == [5.0, 0.5]
-            @test mc[:k] == 8.5
-            @test mc["states"] == [5.0, 0.5]
-
-            # make sure we throw if setindex! doesn't have matching sizes
-            @test_throws ErrorException setindex!(mc3, rand(4), :k, :i, :z)
-
-            # now get back our original mc
-            mc = new_mc()
-
-            # test vector version
-            @test [8.5, 1.1] == @inferred getindex(mc, :k, :i)
-            @test Vector{Float64}[[8.5, 0.5], [1.1]] == @inferred getindex(mc, "states", "controls")
+            @test [8.5, 0.5] == @inferred getindex(mc, :states)
+            @test Vector{Float64}[[8.5, 0.5], [1.1]] == @inferred getindex(mc, :states, :controls)
 
             # test setindex! for a group
-            mc3["states"] = [42.0, 43.0]
-            @test [42.0, 43.0] == @inferred getindex(mc3, "states")
-            @test 42.0 == mc3[:k]
-            @test 43.0 == mc3[:z]
-            @test_throws ErrorException setindex!(mc3, rand(3), "states")
+            mc3[:states] = [42.0, 43.0]
+            @test [42.0, 43.0] == @inferred getindex(mc3, :states)
+            @test 42.0 == mc3.flat[:k]
+            @test 43.0 == mc3.flat[:z]
+            @test_throws DimensionMismatch setindex!(mc3, rand(3), :states)
+
+            # test setindex! for multiple groups
+            mc3[:states, :controls] = [43.0, 42.0], [1.5]
+            @test [43.0, 42.0] == @inferred getindex(mc3, :states)
+            @test [1.5] == @inferred getindex(mc3, :controls)
+            @test 43.0 == mc3.flat[:k]
+            @test 42.0 == mc3.flat[:z]
+            @test 1.5 == mc3.flat[:i]
+            @test_throws DimensionMismatch setindex!(mc3, (rand(2),), :states, :controls)
+            @test_throws DimensionMismatch setindex!(mc3, (rand(3),rand(1)), :states, :controls)
         end
 
         @testset "eval_with" begin


### PR DESCRIPTION
This implements a new set of calibration types.

We now have

```
immutable ModelCalibration
    flat::FlatCalibration
    grouped::GroupedCalibration
    symbol_table::Dict{Symbol,Tuple{Symbol,Int}}
    symbol_groups::OrderedDict{Symbol,Vector{Symbol}}
end
```

Where `FlatCalibration` and `GroupedCalibration` are light wrappers around `OrderedDict` and `Dict` that allow us to customize getindex and setindex! behavior. 

Semantics have changed a little bit for getindex and setindex! for `ModelCalibration`:

- `getindex` is only implemented on symbols and simply forwards on to the grouped set. To get values for specific variables, use `getindex` on the `flat` field
- `setindex!` is also only implemented where keys are symbols, but allows you to set single variables or groups. 