### PR TITLE
Sl/model tidyup

### DIFF
--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -10,7 +10,7 @@ export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
        FlatCalibration, GroupedCalibration, ModelCalibration,
 
        # functions
-       eval_with, evaluate, evaluate!
+       eval_with, evaluate, evaluate!, model_type, name, filename
 
 # set up core types
 abstract AbstractModel

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -291,7 +291,7 @@ function eval_with(mc::ModelCalibration, ex::Expr)
     # put in let block to allow us to define intermediates in expr and not
     # have them become globals in `current_module()` at callsite
     new_ex = MacroTools.prewalk(s->_replace_me(mc, s), ex)
-    eval(:(
+    eval(Dolo, :(
     let
         $new_ex
     end))
@@ -372,7 +372,7 @@ for (TF, TM, ms) in [(:DTCSCCfunctions, :DTCSCCModel, :(:dtcscc)),
                 error(msg)
             end
             $(TF)([let
-                       eval(compile_equation(sm, fld; print_code=print_code))
+                       eval(Dolo, compile_equation(sm, fld; print_code=print_code))
                    end
                    for fld in fieldnames($(TF))]...)
         end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -388,6 +388,12 @@ for (TF, TM, ms) in [(:DTCSCCfunctions, :DTCSCCModel, :(:dtcscc)),
             calib = ModelCalibration(sm)
             options = eval_with(calib, deepcopy(sm.options))
             dist = eval_with(calib, deepcopy(sm.distribution))
+            # hack to parse normal transition matrix into a matrix instead of
+            # a vector of vectors
+            if haskey(dist, :Normal)
+                n = length(calib[:shocks])
+                dist[:Normal] = reshape(vcat(dist[:Normal]...), n, n)
+            end
             $(TM)(sm, $(TF)(sm), calib, options, dist, sm.model_type,
                   sm.name, sm.filename)
         end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -298,15 +298,15 @@ function eval_with(mc::ModelCalibration, ex::Expr)
 end
 
 eval_with(mc::ModelCalibration, s::AbstractString) = eval_with(mc, _to_expr(s))
-eval_with(mc::ModelCalibration, s::Symbol) = _replace_me(m, s)
+eval_with(mc::ModelCalibration, s::Symbol) = _replace_me(mc, s)
 eval_with(mc::ModelCalibration, d::Associative) =
     Dict{Symbol,Any}([(symbol(k), eval_with(mc, v)) for (k, v) in d])
 eval_with(mc::ModelCalibration, x::Number) = x
 eval_with(mc::ModelCalibration, x::AbstractArray) = map(y->eval_with(mc, y), x)
 
-# -------------------- #
-# Model specific types #
-# -------------------- #
+# ------------------- #
+# Numeric model types #
+# ------------------- #
 # TODO: decide if we really want all 8 type params. It doesn't hurt, it just
 #       looks funny
 immutable DTCSCCfunctions{T1,T2,T3,T4,T5,T6,T7,T8}
@@ -398,6 +398,6 @@ end
 # Other methods #
 # ------------- #
 
-model_type(m::Union{ASM,ANM}) = m.model_type
-filename(m::Union{ASM,ANM}) = m.filename
-name(m::Union{ASM,ANM}) = m.name
+model_type(m::AbstractModel) = m.model_type
+filename(m::AbstractModel) = m.filename
+name(m::AbstractModel) = m.name

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -53,7 +53,7 @@ function _param_block(sm::ASM)
 end
 
 function _aux_block(sm::ASM, shift::Int)
-    target = RECIPES[model_spec(sm)][:specs][:auxiliary][:target][1]
+    target = RECIPES[model_type(sm)][:specs][:auxiliary][:target][1]
     targets = sm.symbols[symbol(target)]
     exprs = sm.equations[:auxiliary]
 
@@ -112,7 +112,7 @@ end
 
 function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
     # extract spec from recipe
-    spec = RECIPES[model_spec(sm)][:specs][func_nm]
+    spec = RECIPES[model_type(sm)][:specs][func_nm]
 
     # generate a new type name
     tnm = gensym(func_nm)
@@ -141,7 +141,7 @@ function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
     end
 
     # extract information from spec
-    target = get(RECIPES[model_spec(sm)][:specs][func_nm], :target, [nothing])[1]
+    target = get(RECIPES[model_type(sm)][:specs][func_nm], :target, [nothing])[1]
     targets = target === nothing ? Symbol[] : sm.symbols[symbol(target)]
     eqs = spec[:eqs]  # required, so we don't provide a default
     non_aux = filter(x->x[1] != "auxiliaries", eqs)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,8 @@
+_replace_star_star(s::AbstractString) = replace(s, "**", "^")
+
 _to_expr(x::Expr) = x
 _to_expr(x::Union{Symbol,Number}) = Expr(:block, x)
-_to_expr(x::AbstractString) = _to_expr(parse(x))
+_to_expr(x::AbstractString) = _to_expr(parse(_replace_star_star(x)))
 
 _expr_or_number(x::Union{AbstractString,Symbol,Expr}) = _to_expr(x)
 _expr_or_number(x::Number) = x

--- a/src/util.jl
+++ b/src/util.jl
@@ -34,7 +34,8 @@ function solve_triangular_system(dict::Associative)
             if !haskey(solutions, k)
                 expr = dict[k]
                 try
-                    sol = eval(:(let $([:($x=$y) for (x, y) in solutions]...); $expr end))
+                    sol = eval(Dolo,
+                               :(let $([:($x=$y) for (x, y) in solutions]...); $expr end))
                     solutions[k] = sol
                     done_smthg = true
                 end

--- a/test/model_types.jl
+++ b/test/model_types.jl
@@ -168,6 +168,16 @@
                 end)
             @test !isdefined(current_module(), :foobar)
 
+            @test eval_with(mc, ["k+1", "k+i"]) == [9.5, 9.6]
+            @test eval_with(mc, 1.0) == 1.0
+            @test eval_with(mc, :k) == 8.5
+            @test eval_with(mc, Dict("hi"=>"i", "low"=>"-i")) ==
+                    Dict{Symbol,Any}(:hi => 1.1, :low => -1.1)
+
+            # make sure it works with any associatives
+            @test eval_with(mc, mc.flat) == mc.flat.d
+            @test eval_with(mc, mc.grouped) == mc.grouped.d
+
         end
     end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -67,7 +67,7 @@ type MockSymbolic <: Dolo.ASM
 end
 
 MockSymbolic(d) = MockSymbolic(d, nothing)
-Dolo.model_spec(::MockSymbolic) = :dtcscc
+Dolo.model_type(::MockSymbolic) = :dtcscc
 @testset "compiler" begin
 
     @testset "_param_block" begin
@@ -197,13 +197,13 @@ Dolo.model_spec(::MockSymbolic) = :dtcscc
         # can't compile this type of equation, so calling throws an error.
         # it is still a dolo functor, however
         obj1 = let
-            eval(Dolo.compile_equation(sm, :value))
+            eval(Dolo, Dolo.compile_equation(sm, :value))
         end
         @test_throws ErrorException evaluate(obj1)
         @test @compat(supertype)(typeof(obj1)) == Dolo.AbstractDoloFunctor
 
         obj2 = let
-            eval(Dolo.compile_equation(sm, :auxiliary))
+            eval(Dolo, Dolo.compile_equation(sm, :auxiliary))
         end
         @test @compat(supertype)(typeof(obj2)) == Dolo.AbstractDoloFunctor
 


### PR DESCRIPTION
I do a few things here:

- Add `name`, `filename`, `model_type`, `options`, `distribution` to number model types
- The `options` and `distribution` fields are exact replicas of the corresponding fields in the symbolic model, but all symbols are replaced with numerical values:
```
julia> dump(sm.options)  # symbolic model
Dict{Symbol,Any} len 1
  Approximation: Dict{Symbol,Any} len 3
    orders: Array(Any,(2,))
      1: Int64 10
      2: Int64 50
    b: Array(Any,(2,))
      1: ASCIIString "1+2*sig_z"
      2: ASCIIString "k*1.1"
    a: Array(Any,(2,))
      1: ASCIIString "1-2*sig_z"
      2: ASCIIString "k*0.9"

julia> dump(m.options)  # numeric model
Dict{Symbol,Any} len 1
  Approximation: Dict{Symbol,Any} len 3
    orders: Array(Any,(2,))
      1: Int64 10
      2: Int64 50
    b: Array(Any,(2,))
      1: Float64 1.032
      2: Float64 10.290476119160585
    a: Array(Any,(2,))
      1: Float64 0.968
      2: Float64 8.419480461131387
```
- Added tests for symbolic model constructor
- Added methods `eval_with(mc::ModelCalibration, x)` where `x` is many other things like dicts, arrays, numbers, etc. Calling it on a container type (e.g. Dict) recursively calls `eval_with` until we get down to numbers wherever possible. The numeric version of `sm.options` is obtained by doing `eval_with(calibration, sm.options)`
- Added tests for dtcscc model constructor
- Added tests for dtcscc functions