### PR TITLE
Sl/linear solve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ os:
 julia:
   - release
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -1,13 +1,17 @@
 module Dolo
 
+using Base.Cartesian
+
 using MacroTools
 using DataStructures: OrderedDict
 using YAML: load_file
 using NLsolve
+import ForwardDiff
+using Calculus
 
 export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
        AbstractDoloFunctor, SymbolicModel, DTCSCCModel, DTMSCCModel,
-       FlatCalibration, GroupedCalibration, ModelCalibration,
+       FlatCalibration, GroupedCalibration, ModelCalibration, TaylorExpansion,
 
        # functions
        eval_with, evaluate, evaluate!, model_type, name, filename
@@ -33,6 +37,8 @@ const RECIPES = _symbol_dict(load_file(joinpath(src_path, "recipes.yaml")))
 include("util.jl")
 include("parser.jl")
 include("model_types.jl")
+
+include("numeric/taylor_series.jl")
 
 include("algos/dtcscc.jl")
 

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -1,13 +1,10 @@
 module Dolo
 
-using Base.Cartesian
-
 using MacroTools
 using DataStructures: OrderedDict
 using YAML: load_file
 using NLsolve
 import ForwardDiff
-using Calculus
 
 export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
        AbstractDoloFunctor, SymbolicModel, DTCSCCModel, DTMSCCModel,

--- a/src/algos/dtcscc.jl
+++ b/src/algos/dtcscc.jl
@@ -28,3 +28,91 @@ function solve_steady_state(m::DTCSCCModel, mc::ModelCalibration=m.calibration)
     out[:controls] = sol.zero[ns+1:end]
     out
 end
+
+# define custom exception types that hold some data for us to catch/explore
+immutable GeneralizedEigenvaluesError <: Exception
+    msg::AbstractString
+    diag_S::Vector{Float64}
+    diag_T::Vector{Float64}
+end
+
+immutable BlanchardKahnError <: Exception
+    msg::AbstractString
+    n_found::Int
+    n_expected::Int
+end
+
+function _check_gev(diag_S, diag_T, tol)
+    ok = sum((abs(diag_S) .< tol) .* (abs(diag_T) .< tol)) == 0
+    if !ok
+        msg = "Eigenvalues are not uniquely defined."
+        throw(GeneralizedEigenvaluesError(msg, diag_S, diag_T))
+    end
+    true
+end
+
+function _check_bk_conditions(eigval, tol, n_expected)
+    n_big = sum(eigval .> tol)
+    if n_expected != n_big
+        msg = """
+        There are $(n_big) eigenvalues greater than one.
+        There should be exactly $(n_expected) to meet Blanchard-Kahn conditions.
+        """
+        throw(BlanchardKahnError(msg, n_big, n_expected))
+    end
+    true
+end
+
+function linear_solve(m::DTCSCCModel, calib::ModelCalibration=m.calibration;
+                      verbose::Bool=false, eigtol::Float64=1.0+1e-6)
+    f = m.functions.arbitrage
+    g = m.functions.transition
+
+    p, s, x, e = calib[:parameters, :states, :controls, :shocks]
+    ns = length(s)
+    nx = length(x)
+    ne = length(e)
+    nv = ns + nx
+
+    # evaluate Jacobians and stack into A,B matrix for qz
+    g_s, g_x, g_e = eval_jacobians(g, (s, x, e), p)
+    f_s, f_x, f_e, f_S, f_X = eval_jacobians(f, (s, x, e, s, x), p)
+
+    A = [eye(ns) zeros(ns, nx)
+         -f_S     -f_X]
+    B = [g_s g_x
+         f_s f_x]
+
+    # do orderd QZ decomposition
+    gs = schurfact(A, B)
+    select = (abs(gs[:alpha]) .> eigtol*abs(gs[:beta]))
+    ordschur!(gs, select)
+    S, T, Q, Z = gs[:S], gs[:T], gs[:Q], gs[:Z]
+    diag_S = diag(S)
+    diag_T = diag(T)
+    eigval = abs(diag_S./diag_T)
+
+    # check eigen values and BK conditions
+    _check_gev(diag_S, diag_T, 1e-10)
+    _check_bk_conditions(eigval, eigtol, nx)
+
+    # now obtain first order solution
+    Z11 = Z[1:ns, 1:ns]
+    Z12 = Z[1:ns, ns+1:end]
+    Z21 = Z[ns+1:end, 1:ns]
+    Z22 = Z[ns+1:end, ns+1:end]
+    S11 = S[1:ns, 1:ns]
+    T11 = T[1:ns, 1:ns]
+
+    # first order solution
+    C = (Z11'\Z21')'
+    # P = (S11'\Z11')'*(Z11'\T11')'
+    # Q = g_e
+    # A = g_s + g_x*C
+    # B = g_e
+
+    dr = TaylorExpansion(s, x, C)
+    # dr.A = A
+    # dr.B = B
+    # dr.sigma = get(m.distribution, :Normal, zeros(ne, ne))
+end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -266,7 +266,7 @@ function Base.setindex!(mc::ModelCalibration, v, k::Symbol)
     elseif haskey(mc.symbol_groups, k)  # setting a group
         _setindex_group!(mc, v, k)
     else
-        throw(KeyError("ModelCalibration has no variable or groupe named $k"))
+        throw(KeyError("ModelCalibration has no variable or group named $k"))
     end
 end
 

--- a/src/numeric/taylor_series.jl
+++ b/src/numeric/taylor_series.jl
@@ -1,0 +1,114 @@
+immutable TaylorExpansion{order}
+    s0::Vector{Float64}
+    x0::Vector{Float64}
+    x_1::Array{Float64,2}
+    x_2::Array{Float64,3}
+    x_3::Array{Float64,4}
+end
+
+TaylorExpansion(s0, x0, x_1) =
+    TaylorExpansion{1}(s0, x0, x_1, zeros(0, 0, 0), zeros(0, 0, 0, 0))
+
+TaylorExpansion(s0, x0, x_1, x_2) =
+    TaylorExpansion{2}(s0, x0, x_1, x_2, zeros(0, 0, 0, 0))
+
+TaylorExpansion(s0, x0, x_1, x_2, x_3) =
+    TaylorExpansion{3}(s0, x0, x_1, x_2, x_3)
+
+
+function _check_call(ts::TaylorExpansion, points, out)
+    ns = length(ts.s0)
+    nx = length(ts.x0)
+
+    if size(points, 1) != ns
+        msg = "Points should be of length $(ns), found $(size(points, 1))"
+        throw(DimensionMismatch(msg))
+    end
+
+    if size(out, 1) != nx
+        msg = "out should be of length $(nx), found $(size(out, 1))"
+        throw(DimensionMismatch(msg))
+    end
+
+    if size(out, 2) != size(points, 2)
+        msg = "Out should have same number of columns as points"
+        throw(DimensionMismatch(msg))
+    end
+end
+
+# points should be a vector of observations of all state variables at one time
+# period
+function Base.call(ts::TaylorExpansion{1}, points::AbstractVector,
+                   out::AbstractVector=similar(ts.x0))
+    _check_call(ts, points, out)
+    s0, x0, x_1 = ts.s0, ts.x0, ts.x_1
+    ns = length(s0)
+    nx = length(x0)
+
+    copy!(out, x0)
+
+    @inbounds for i in 1:ns
+        @simd for n in 1:nx
+            out[n] += x_1[n, i]*(points[i] - s0[i])
+        end
+    end
+    out
+end
+
+function Base.call(ts::TaylorExpansion{2}, points::AbstractVector,
+                   out::AbstractVector=similar(ts.x0))
+    _check_call(ts, points, out)
+    s0, x0, x_1, x_2 = ts.s0, ts.x0, ts.x_1, ts.x_2
+    ns = length(s0)
+    nx = length(x0)
+
+    copy!(out, x0)
+
+    @inbounds for j in 1:ns
+        foo_j = points[j] - s0[j]
+        for i in 1:ns
+            foo_i = points[i] - s0[i]
+            @simd for n in 1:nx
+                out[n] += x_1[n, i]*foo_i
+                out[n] += x_2[n, i, j]*foo_i*(foo_j)/2.0
+            end
+        end
+    end
+    out
+end
+
+function Base.call(ts::TaylorExpansion{3}, points::AbstractVector,
+                   out::AbstractVector=similar(ts.x0))
+    _check_call(ts, points, out)
+    s0, x0, x_1, x_2, x_3 = ts.s0, ts.x0, ts.x_1, ts.x_2, ts.x_3
+    ns = size(points, 1)
+    nx = size(x0, 1)
+
+    copy!(out, x0)
+
+    @inbounds for k in 1:ns
+        Δk = points[k] - s0[k]
+        for j in 1:ns
+            Δj = points[j] - s0[j]
+            for i in 1:ns
+                Δi = points[i] - s0[i]
+                @simd for n in 1:nx
+                    out[n] += x_1[n, i]*Δi
+                    out[n] += x_2[n, i, j]*Δi*(Δj)/2.0
+                    out[n] += x_3[n, i, j, k]*(Δi)*(Δj)*(Δk)/6.0
+                end
+            end
+        end
+    end
+    out
+end
+
+# Each column is an observation of all the state variables
+function Base.call(ts::TaylorExpansion, points::AbstractMatrix,
+                   out::AbstractMatrix=Array(Float64, length(ts.x0), size(points, 2)))
+    _check_call(ts, points, out)
+    for n in 1:size(points, 2)
+        ts(sub(points, :, n), sub(out, :, n))
+    end
+    out
+end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -185,6 +185,8 @@ function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
             evaluate!(o, $(arg_names...), out)
         end
 
+        Base.length(::$tnm) = $(length(exprs))
+
         # last line of this block is the singleton instance of the type
         # This means you should do `obj = eval(code)`
         $tnm()

--- a/src/util.jl
+++ b/src/util.jl
@@ -125,3 +125,29 @@ function _handle_arbitrage(arb, controls)
     end
     controls_lb, controls_ub, arbitrage
 end
+
+# function eval_jacobian(f::AbstractDoloFunctor, before::Tuple, to_diff::Tuple,
+#                        after::Tuple, i::Int)
+#     _f(_) = evaluate(f, before..., to_diff[1:i-1]..., _, to_diff[i+1:end]..., after...)
+#     jacobian(_f, to_diff[i], :forward)::Matrix{Float64}
+# end
+
+function eval_jacobian(f::AbstractDoloFunctor, before::Tuple, to_diff::Tuple,
+                       after::Tuple, i::Int)
+    _f!(out, _) = evaluate!(f, before..., to_diff[1:i-1]..., _, to_diff[i+1:end]..., after..., out)
+    j! = ForwardDiff.jacobian(_f!; mutates=true, output_length=length(f))
+    out = Array(Float64, length(f), length(to_diff[i]))
+    j!(out, to_diff[i])
+    out
+end
+
+
+function eval_jacobians(f::AbstractDoloFunctor, before::Tuple, to_diff::Tuple,
+                        after...)
+    out = map(i->eval_jacobian(f, before, to_diff, after, i), 1:length(to_diff))
+    out::Vector{Matrix{Float64}}
+end
+
+# no arguments before, just pass empty tuple
+eval_jacobians(f::AbstractDoloFunctor, to_diff::Tuple, after...) =
+    eval_jacobians(f, tuple(), to_diff, after...)

--- a/test/numeric.jl
+++ b/test/numeric.jl
@@ -1,0 +1,32 @@
+@testset "TaylorExpansion" begin
+    s0 = [0.2, 0.4, 1.1]
+    x0 = [1.2, 0.9]
+
+    N = 1000
+    points = rand(3, N)
+
+    X_s = rand(2, 3)
+    X_ss = rand(2, 3, 3)
+    X_sss = rand(2, 3, 3, 3)
+    dr1 = TaylorExpansion(s0, x0, X_s)
+    dr2 = TaylorExpansion(s0, x0, X_s, X_ss)
+    dr3 = TaylorExpansion(s0, x0, X_s, X_ss, X_sss)
+
+    out1 = dr1(points)
+    out2 = dr2(points)
+    out3 = dr3(points)
+
+    out1_1d = dr1(points[:, 1])
+    out2_1d = dr2(points[:, 1])
+    out3_1d = dr3(points[:, 1])
+
+    @test maxabs(out1_1d - out1[:, 1]) == 0.0
+    @test maxabs(out2_1d - out2[:, 1]) == 0.0
+    @test maxabs(out3_1d - out3[:, 1]) == 0.0
+
+    ds = points .- s0
+    verif1 = x0 .+ X_s*ds
+    @test maxabs(out1 - verif1) < 1e-12
+
+    # TODO: write verification tests for 2d and 3d
+end

--- a/test/numeric.jl
+++ b/test/numeric.jl
@@ -3,7 +3,7 @@
     x0 = [1.2, 0.9]
 
     N = 1000
-    points = rand(3, N)
+    points = rand(N, 3)
 
     X_s = rand(2, 3)
     X_ss = rand(2, 3, 3)
@@ -16,17 +16,17 @@
     out2 = dr2(points)
     out3 = dr3(points)
 
-    out1_1d = dr1(points[:, 1])
-    out2_1d = dr2(points[:, 1])
-    out3_1d = dr3(points[:, 1])
+    out1_1d = dr1(vec(points[1, :]))
+    out2_1d = dr2(vec(points[1, :]))
+    out3_1d = dr3(vec(points[1, :]))
 
-    @test maxabs(out1_1d - out1[:, 1]) == 0.0
-    @test maxabs(out2_1d - out2[:, 1]) == 0.0
-    @test maxabs(out3_1d - out3[:, 1]) == 0.0
+    @test maxabs(out1_1d - vec(out1[1, :])) == 0.0
+    @test maxabs(out2_1d - vec(out2[1, :])) == 0.0
+    @test maxabs(out3_1d - vec(out3[1, :])) == 0.0
 
-    ds = points .- s0
-    verif1 = x0 .+ X_s*ds
-    @test maxabs(out1 - verif1) < 1e-12
+    ds = points .- s0'
+    verif1 = x0 .+ X_s*ds'
+    @test maxabs(out1 - verif1') < 1e-12
 
     # TODO: write verification tests for 2d and 3d
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Dolo
 using Compat
 using DataStructures
 
-# write your own tests here
 if VERSION >= v"0.5-"
     using Base.Test
 else
@@ -10,6 +9,7 @@ else
     const Test = BaseTestNext
 end
 
+include("numeric.jl")
 include("parser.jl")
 include("util.jl")
 include("model_types.jl")


### PR DESCRIPTION
Very simple linear solver for dtcscc models.

Test it with the rbc model using:

```julia
using Dolo
using YAML: load_file
# replace with path to rbc model in your dolo.py
src = load_file("/Users/sglyon/src/Python/dolo/examples/models/rbc.yaml")
sm = SymbolicModel(src, :dtcscc)
m = DTCSCCModel(sm)
ts = linear_solve(m)
```

Then `ts` is an object of type  `TaylorExpansion`, which has `call` implemented for it.