### PR TITLE
WIP: vectorized eval

### DIFF
--- a/src/model_import.jl
+++ b/src/model_import.jl
@@ -11,7 +11,7 @@ function guess_model_type(data)
     end
 end
 
-function yaml_import(url)
+function yaml_import(url; print_code::Bool=false)
 
     if match(r"(http|https):.*", url) != nothing
         res = get(url)
@@ -28,9 +28,9 @@ function yaml_import(url)
     sym_model = SymbolicModel(data, model_type, fname)
 
     if model_type == :dtcscc
-        return DTCSCCModel(sym_model)
+        return DTCSCCModel(sym_model; print_code=print_code)
     elseif model_type == :dtmscc
-        return DTMSCCModel(sym_model)
+        return DTMSCCModel(sym_model; print_code=print_code)
     else
         throw(Exception)
     end

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -379,7 +379,7 @@ for (TF, TM, ms) in [(:DTCSCCfunctions, :DTCSCCModel, :(:dtcscc)),
         Base.convert(::Type{SymbolicModel}, m::$(TM)) = m.symbolic
 
         # model type constructor
-        function Base.convert(::Type{$TM}, sm::SymbolicModel)
+        function ($TM)(sm::SymbolicModel; print_code::Bool=false)
             if model_type(sm) != model_type($TM)
                 msg = string("Symbolic model is of type $(model_type(sm)) ",
                              "cannot create model of type $($TM)")
@@ -394,7 +394,8 @@ for (TF, TM, ms) in [(:DTCSCCfunctions, :DTCSCCModel, :(:dtcscc)),
                 n = length(calib[:shocks])
                 dist[:Normal] = reshape(vcat(dist[:Normal]...), n, n)
             end
-            $(TM)(sm, $(TF)(sm), calib, options, dist, sm.model_type,
+            funcs = $(TF)(sm; print_code=print_code)
+            $(TM)(sm, funcs, calib, options, dist, sm.model_type,
                   sm.name, sm.filename)
         end
     end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -6,7 +6,7 @@ call_expr(var, n) = n == 0 ? symbol(var) :
 
 function eq_expr(ex::Expr, targets::Union{Vector{Expr},Vector{Symbol}}=Symbol[])
     if isempty(targets)
-        return Expr(:call, :(-), _parse(ex.args[2]), _parse(ex.args[1]))
+        return Expr(:call, :(.-), _parse(ex.args[2]), _parse(ex.args[1]))
     end
 
     # ensure lhs is in targets
@@ -30,6 +30,17 @@ function _parse(ex::Expr; targets::Union{Vector{Expr},Vector{Symbol}}=Symbol[])
         # translate x(n) --> x__n_ and x(-n) -> x_mn_
         var_(shift_Integer) => _parse(call_expr(var, shift))
 
+        # + and * can take multiple arguments. Need to slurp them
+        +(a_, b_) => Expr(:call, :(.+), _parse(a), _parse(b))
+        +(a_, b_, c__) => _parse(Expr(:call, :(+), Expr(:call, :(.+), a, b), c...))
+        *(a_, b_) => Expr(:call, :(.*), _parse(a), _parse(b))
+        *(a_, b_, c__) => _parse(Expr(:call, :(*), Expr(:call, :(.*), a, b), c...))
+
+        # -, /, ^ can only take two at a time
+        -(a_, b_) => Expr(:call, :(.-), _parse(a), _parse(b))
+        /(a_, b_) => Expr(:call, :(./), _parse(a), _parse(b))
+        ^(a_, b_) => Expr(:call, :(.^), _parse(a), _parse(b))
+
         # Other func calls. Just parse args. Allows arbitrary Julia functions
         f_(a__) => Expr(:call, f, map(_parse, a)...)
 
@@ -46,10 +57,13 @@ _parse(s::AbstractString; kwargs...) = _parse(parse(s); kwargs...)
 # Compiler #
 # -------- #
 
+@inline _unpack_var(x::AbstractVector, i::Integer) = x[i]
+@inline _unpack_var(x::AbstractMatrix, i::Integer) = sub(x, :, i)
+
 function _param_block(sm::ASM)
     params = sm.symbols[:parameters]
     Expr(:block,
-         [:(@inbounds $(_parse(params[i])) = p[$i]) for i in 1:length(params)]...)
+         [:(@inbounds $(_parse(params[i])) = _unpack_var(p, $i)) for i in 1:length(params)]...)
 end
 
 function _aux_block(sm::ASM, shift::Int)
@@ -94,20 +108,96 @@ function _single_arg_block(sm::ASM, arg_name::Symbol, arg_type::Symbol,
     nms = sm.symbols[arg_type]
     # TODO: extract columns at a time when Ndim > 1
     Expr(:block,
-         [:(@inbounds $(_parse("$(nms[i])($(shift))")) = $(arg_name)[$i])
+         [:(@inbounds $(_parse("$(nms[i])($(shift))")) = _unpack_var($(arg_name),$i))
             for i in 1:length(nms)]...)
 end
 
+@inline _assign_var(lhs::AbstractVector, rhs::Number, i) = setindex!(lhs, rhs, i)
+@inline _assign_var(lhs::AbstractMatrix, rhs::AbstractVector, i) = setindex!(lhs, rhs, :, i)
+
 "returns an expression `:(lhs[i] = rhs)`"
-_assign_single_el(lhs, rhs, i) = :($lhs[$i] = $rhs)
+_assign_var_expr(lhs, rhs, i) = :(_assign_var($lhs, $rhs, $i))
 
 "Evaluates main expressions in a function group and fills `out` with results"
 function _main_body_block(sm::ASM, targets::Vector{Symbol}, exprs::Vector{Expr})
     n_expr = length(exprs)
-    parsed_eprs = map(x->_parse(x; targets=targets), exprs)
-    assignments = map((rhs,i)->_assign_single_el(:out, rhs, i),
-                      parsed_eprs, 1:n_expr)
-    func_block = Expr(:block, assignments...)
+    parsed_exprs = map(x->_parse(x; targets=targets), exprs)
+    if isempty(targets)
+        # no targets, just set out = parsed_expr
+        assignments = map((rhs,i)->_assign_var_expr(:out, rhs, i),
+                          parsed_exprs, 1:n_expr)
+        func_block = Expr(:block, assignments...)
+    else
+        # otherwise, need to parse the targets, evaluate them, and then set
+        # elements of out equal to the targets
+        parsed_targets = map(_parse, targets)
+        assignments = map((rhs,i)->_assign_var_expr(:out, rhs, i),
+                          parsed_targets, 1:n_expr)
+        func_block = Expr(:block, parsed_exprs..., assignments...)
+    end
+end
+
+"checks that lhs of expr is equal to target"
+function _check_target(expr::Expr, target::Symbol, func_nm::Symbol, i::Int)
+    out = @match expr begin
+        $(Expr(:(=), :__)) => expr.args[1]
+        _ => false
+    end
+
+    if isa(out, Bool)
+        error("Equations of type $func_nm must be of the form `lhs=rhs`")
+    end
+
+    # otherwise we got a symbol
+    if out != target
+        msg = string("In equation of type $func_nm expected $target on the ",
+                     " left hand side of the equation $(i)")
+        error(msg)
+    end
+
+end
+
+function _check_targets(exprs, targets, func_nm)
+    nt = length(targets)
+    ne = length(exprs)
+    if nt != ne
+        msg = "For equation group $func_nm expected $nt equations, found $ne"
+        error(msg)
+    end
+
+    map((e, t, i) -> _check_target(e, t, func_nm, i), exprs, targets, 1:nt)
+    nothing
+end
+
+_output_size(n_expr::Int, args::AbstractVector...) = (n_expr,)
+function _output_size(n_expr::Int, args...)
+    n_row = 0
+    # get maximum number of rows among matrix arguments
+    for a in args
+        if isa(a, AbstractMatrix)
+            nr = size(a, 1)
+            if n_row > 0
+                # we already found another matrix argument, now we can enforce
+                # that all matrix arguments have conformable shapes
+                if nr != n_row
+                    msg = string("Unconformable argument sizes. For vectorized ",
+                                 "evaluation all matrix arguments must have ",
+                                 "the same number of rows.")
+                    throw(DimensionMismatch(msg))
+                end
+            else
+                # we need to update n_row
+                n_row = nr
+            end
+        end
+    end
+    (n_row, n_expr)
+end
+
+_allocate_out(T::Type, n_expr::Int, args::AbstractVector...) = Array(T, n_expr)
+function _allocate_out(T::Type, n_expr::Int, args...)
+    sz = _output_size(n_expr, args...)
+    Array(T, sz[1], sz[2])
 end
 
 function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
@@ -141,8 +231,7 @@ function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
     end
 
     # extract information from spec
-    target = get(RECIPES[model_type(sm)][:specs][func_nm], :target, [nothing])[1]
-    targets = target === nothing ? Symbol[] : sm.symbols[symbol(target)]
+    target = get(spec, :target, [nothing])[1]
     eqs = spec[:eqs]  # required, so we don't provide a default
     non_aux = filter(x->x[1] != "auxiliaries", eqs)
     arg_names = Symbol[symbol(x[3]) for x in non_aux]
@@ -150,6 +239,11 @@ function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
     arg_shifts = Int[x[2] for x in non_aux]
     only_aux = filter(x->x[1] == "auxiliaries", eqs)
     aux_shifts = Int[x[2] for x in only_aux]
+
+    # extract targets and make sure they appear in the correct order in exprs
+    has_targets = !(target === nothing)
+    targets = has_targets ? sm.symbols[symbol(target)] : Symbol[]
+    has_targets && _check_targets(exprs, targets, func_nm)
 
     # build function block by block
     all_arg_blocks = map((a,b,c) -> _single_arg_block(sm, a, b, c),
@@ -167,7 +261,8 @@ function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
         out  # return out
     end
 
-    typed_args = [Expr(:(::), s, :AbstractVector) for s in arg_names]
+    typed_args = [Expr(:(::), s, :(Union{AbstractVector,AbstractMatrix}))
+                  for s in arg_names]
 
     # build the new type and implement methods on Base.call that we need
     code = quote
@@ -176,12 +271,18 @@ function compile_equation(sm::ASM, func_nm::Symbol; print_code::Bool=false)
 
         # non-allocating function
         function evaluate!(::$tnm, $(typed_args...), out)
-            $body  # evaluateuates equations and populates `out`
+            expected_size = _output_size($(length(exprs)), $(arg_names...))
+            if size(out) != expected_size
+                msg = "Expected out to be size $(expected_size), found $(size(out))"
+                throw(DimensionMismatch(msg))
+            end
+            $body  # evaluates equations and populates `out`
         end
 
         # allocating version
         function evaluate(o::$tnm, $(typed_args...))
-            out = Array(eltype($(arg_names[1])), $(length(exprs)))
+            out = _allocate_out(eltype($(arg_names[1])),
+                                $(length(exprs)), $(arg_names...))
             evaluate!(o, $(arg_names...), out)
         end
 

--- a/src/recipes.yaml
+++ b/src/recipes.yaml
@@ -92,14 +92,12 @@ dtcscc:
 
         controls_lb:
             optional: True
-            target: ['controls', 0, 'lb']
             eqs:
                 - ['states', 0, 's']
                 - ['parameters', 0, 'p']
 
         controls_ub:
             optional: True
-            target: ['controls', 0, 'ub']
             eqs:
                 - ['states', 0, 's']
                 - ['parameters', 0, 'p']

--- a/src/recipes.yaml
+++ b/src/recipes.yaml
@@ -202,7 +202,6 @@ dtmscc:
 
         controls_lb:
             optional: True
-            target: ['controls', 0, 'lb']
             eqs:
                 - ['markov_states',0,'m']
                 - ['states', 0, 's']
@@ -210,7 +209,6 @@ dtmscc:
 
         controls_ub:
             optional: True
-            target: ['controls', 0, 'ub']
             eqs:
                 - ['markov_states',0,'m']
                 - ['states', 0, 's']

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -81,9 +81,9 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
         sm = MockSymbolic(Dict(:parameters => [:a, :b, :foobar]))
         have = Dolo._param_block(sm)
         @test have.head == :block
-        @test have.args[1] == :(@inbounds a_ = _unpack_var(p, 1))
-        @test have.args[2] == :(@inbounds b_ = _unpack_var(p, 2))
-        @test have.args[3] == :(@inbounds foobar_ = _unpack_var(p, 3))
+        @test have.args[1] == :(a_ = _unpack_var(p, 1))
+        @test have.args[2] == :(b_ = _unpack_var(p, 2))
+        @test have.args[3] == :(foobar_ = _unpack_var(p, 3))
     end
 
     @testset "_single_arg_block" begin
@@ -92,22 +92,22 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
         @testset "no shift" begin
             have = Dolo._single_arg_block(sm, :s, :states, 0)
             @test have.head == :block
-            @test have.args[1] == :(@inbounds z_ = _unpack_var(s, 1))
-            @test have.args[2] == :(@inbounds k_ = _unpack_var(s, 2))
+            @test have.args[1] == :(z_ = _unpack_var(s, 1))
+            @test have.args[2] == :(k_ = _unpack_var(s, 2))
         end
 
         @testset "positive shift" begin
             have = Dolo._single_arg_block(sm, :s, :states, 1)
             @test have.head == :block
-            @test have.args[1] == :(@inbounds z__1_ = _unpack_var(s, 1))
-            @test have.args[2] == :(@inbounds k__1_ = _unpack_var(s, 2))
+            @test have.args[1] == :(z__1_ = _unpack_var(s, 1))
+            @test have.args[2] == :(k__1_ = _unpack_var(s, 2))
         end
 
         @testset "negative shift" begin
             have = Dolo._single_arg_block(sm, :s, :states, -1)
             @test have.head == :block
-            @test have.args[1] == :(@inbounds z_m1_ = _unpack_var(s, 1))
-            @test have.args[2] == :(@inbounds k_m1_ = _unpack_var(s, 2))
+            @test have.args[1] == :(z_m1_ = _unpack_var(s, 1))
+            @test have.args[2] == :(k_m1_ = _unpack_var(s, 2))
         end
     end
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -38,10 +38,17 @@
 
         @testset "more args" begin
             for i=3:10
-                ex = Expr(:call, :(+), [:(x($j)) for j in 1:i]...)
-                want = Expr(:call, :(+), [symbol("x__", j, "_") for j in 1:i]...)
+                ex = Expr(:call, :my_func, [:(x($j)) for j in 1:i]...)
+                want = Expr(:call, :my_func, [symbol("x__", j, "_") for j in 1:i]...)
                 @test Dolo._parse(ex) == want
             end
+        end
+
+        @testset "arithmetic" begin
+            @test Dolo._parse(:(a(1) + b + c(2) + d(-1))) == :(((a__1_ .+ b_) .+ c__2_) .+ d_m1_)
+            @test Dolo._parse(:(a(1) * b * c(2) * d(-1))) == :(((a__1_ .* b_) .* c__2_) .* d_m1_)
+            @test Dolo._parse(:(a(1) - b - c(2) - d(-1))) == :(((a__1_ .- b_) .- c__2_) .- d_m1_)
+            @test Dolo._parse(:(a(1) ^ b)) == :(a__1_ .^ b_)
         end
 
         @testset "throws errors when unsupported" begin
@@ -51,7 +58,7 @@
 
     @testset "Expr(:(=), ...)" begin
         @testset "without targets" begin
-            @test Dolo._parse(:(x = y)) == :(y_ - x_)
+            @test Dolo._parse(:(x = y)) == :(y_ .- x_)
         end
 
         @testset "with targets" begin
@@ -74,9 +81,9 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
         sm = MockSymbolic(Dict(:parameters => [:a, :b, :foobar]))
         have = Dolo._param_block(sm)
         @test have.head == :block
-        @test have.args[1] == :(@inbounds a_ = p[1])
-        @test have.args[2] == :(@inbounds b_ = p[2])
-        @test have.args[3] == :(@inbounds foobar_ = p[3])
+        @test have.args[1] == :(@inbounds a_ = _unpack_var(p, 1))
+        @test have.args[2] == :(@inbounds b_ = _unpack_var(p, 2))
+        @test have.args[3] == :(@inbounds foobar_ = _unpack_var(p, 3))
     end
 
     @testset "_single_arg_block" begin
@@ -85,28 +92,28 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
         @testset "no shift" begin
             have = Dolo._single_arg_block(sm, :s, :states, 0)
             @test have.head == :block
-            @test have.args[1] == :(@inbounds z_ = s[1])
-            @test have.args[2] == :(@inbounds k_ = s[2])
+            @test have.args[1] == :(@inbounds z_ = _unpack_var(s, 1))
+            @test have.args[2] == :(@inbounds k_ = _unpack_var(s, 2))
         end
 
         @testset "positive shift" begin
             have = Dolo._single_arg_block(sm, :s, :states, 1)
             @test have.head == :block
-            @test have.args[1] == :(@inbounds z__1_ = s[1])
-            @test have.args[2] == :(@inbounds k__1_ = s[2])
+            @test have.args[1] == :(@inbounds z__1_ = _unpack_var(s, 1))
+            @test have.args[2] == :(@inbounds k__1_ = _unpack_var(s, 2))
         end
 
         @testset "negative shift" begin
             have = Dolo._single_arg_block(sm, :s, :states, -1)
             @test have.head == :block
-            @test have.args[1] == :(@inbounds z_m1_ = s[1])
-            @test have.args[2] == :(@inbounds k_m1_ = s[2])
+            @test have.args[1] == :(@inbounds z_m1_ = _unpack_var(s, 1))
+            @test have.args[2] == :(@inbounds k_m1_ = _unpack_var(s, 2))
         end
     end
 
     @testset "_assign_single_el" begin
-        @test Dolo._assign_single_el(:out, Inf, 1) == :(out[1] = $Inf)
-        @test Dolo._assign_single_el(:z__m_1, 0, :foo) == :(z__m_1[foo]=0)
+        @test Dolo._assign_var_expr(:out, Inf, 1) == :(_assign_var(out, $Inf, 1))
+        @test Dolo._assign_var_expr(:z__m_1, 0, :foo) == :(_assign_var(z__m_1, 0, foo))
     end
 
     @testset "_main_body_block" begin
@@ -116,9 +123,12 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
             exprs = [:(x = sin(42.0)), :(y = x(-1) + cos(42.0)), :(z = tan(x))]
             have = Dolo._main_body_block(sm, targets, exprs)
             @test have.head == :block
-            @test have.args[1] == :(out[1] = x_ = sin(42.0))
-            @test have.args[2] == :(out[2] = y_ = x_m1_ + cos(42.0))
-            @test have.args[3] == :(out[3] = z_ = tan(x_))
+            @test have.args[1] == :(x_ = sin(42.0))
+            @test have.args[2] == :(y_ = x_m1_ .+ cos(42.0))
+            @test have.args[3] == :(z_ = tan(x_))
+            @test have.args[4] == :(_assign_var(out, x_, 1))
+            @test have.args[5] == :(_assign_var(out, y_, 2))
+            @test have.args[6] == :(_assign_var(out, z_, 3))
         end
 
         @testset "throws proper errors" begin
@@ -142,54 +152,61 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
             exprs = [:(x = sin(42.0)), :(y = x(-1)+cos(42.0)), :(z+y = tan(x))]
             have = Dolo._main_body_block(sm, targets, exprs)
             @test have.head == :block
-            @test have.args[1] == :(out[1] = sin(42.0) - x_)
-            @test have.args[2] == :(out[2] = x_m1_ + cos(42.0) - y_)
-            @test have.args[3] == :(out[3] = tan(x_) - (z_ + y_))
+            @test have.args[1] == :(_assign_var(out, sin(42.0) .- x_, 1))
+            @test have.args[2] == :(_assign_var(out, x_m1_ .+ cos(42.0) .- y_, 2))
+            @test have.args[3] == :(_assign_var(out, tan(x_) .- (z_ .+ y_), 3))
         end
     end
 
     # the next two testsets use this data
+    # NOTE: I know that transition specifies equations in the wrong order.
+    # NOTE: I know that the functions for expecation have too many variables
+    #       these are part of the tests below
     exprs = [parse("y = z*k^alpha*n^(1-alpha)"),
              parse("c = y - i"),
              parse("rk = alpha*y/k"),
              parse("w = (1-alpha)*y/n")]
-    sm = MockSymbolic(Dict(:auxiliaries => [:y, :rk, :w, :c],
+    sm = MockSymbolic(Dict(:auxiliaries => [:y, :c, :rk, :w],
                            :states => [:z, :k],
+                           :shocks => [:ɛz],
                            :controls => [:i, :n],
+                           :expectations => [:Ez],
                            :parameters => [:fizz, :buzz, :alpha]),
-                      Dict(:auxiliary => exprs, :value => Expr[]))
+                      Dict(:auxiliary => exprs, :value => Expr[],
+                           :transition => [:(k = k(-1) + 1), :(z = z(-1))],
+                           :expectation => [:(Ez = z(1)), :(Ek = k(1))]))
 
     @testset "_aux_block" begin
         @testset "without shift" begin
             have = Dolo._aux_block(sm, 0)
             @test have.head == :block
-            @test have.args[1] == :(y_ = z_*k_^alpha_*n_^(1-alpha_))
-            @test have.args[2] == :(c_ = y_ - i_)
-            @test have.args[3] == :(rk_ = alpha_*y_/k_)
-            @test have.args[4] == :(w_ = (1-alpha_)*y_/n_)
+            @test have.args[1] == :(y_ = z_.*k_.^alpha_.*n_.^(1.-alpha_))
+            @test have.args[2] == :(c_ = y_ .- i_)
+            @test have.args[3] == :(rk_ = alpha_.*y_./k_)
+            @test have.args[4] == :(w_ = (1.-alpha_).*y_./n_)
         end
 
         @testset "positive shift" begin
             have = Dolo._aux_block(sm, 1)
             @test have.head == :block
-            @test have.args[1] == :(y__1_ = z__1_*k__1_^alpha_*n__1_^(1-alpha_))
-            @test have.args[2] == :(c__1_ = y__1_ - i__1_)
+            @test have.args[1] == :(y__1_ = z__1_.*k__1_.^alpha_.*n__1_.^(1.-alpha_))
+            @test have.args[2] == :(c__1_ = y__1_ .- i__1_)
 
             # notice below that we have k and rk, but that the single shift was
             # properly applied one time to each of them. Had we not used regex
             # in _aux_block and just searched for the state, then control, then
             # auxiliary name we would have gotten rk(1)(1) instead of rk(1)
-            @test have.args[3] == :(rk__1_ = alpha_*y__1_/k__1_)
-            @test have.args[4] == :(w__1_ = (1-alpha_)*y__1_/n__1_)
+            @test have.args[3] == :(rk__1_ = alpha_.*y__1_./k__1_)
+            @test have.args[4] == :(w__1_ = (1.-alpha_).*y__1_./n__1_)
         end
 
         @testset "negative shift" begin
             have = Dolo._aux_block(sm, -2)
             @test have.head == :block
-            @test have.args[1] == :(y_m2_ = z_m2_*k_m2_^alpha_*n_m2_^(1-alpha_))
-            @test have.args[2] == :(c_m2_ = y_m2_ - i_m2_)
-            @test have.args[3] == :(rk_m2_ = alpha_*y_m2_/k_m2_)
-            @test have.args[4] == :(w_m2_ = (1-alpha_)*y_m2_/n_m2_)
+            @test have.args[1] == :(y_m2_ = z_m2_.*k_m2_.^alpha_.*n_m2_.^(1.-alpha_))
+            @test have.args[2] == :(c_m2_ = y_m2_ .- i_m2_)
+            @test have.args[3] == :(rk_m2_ = alpha_.*y_m2_./k_m2_)
+            @test have.args[4] == :(w_m2_ = (1.-alpha_).*y_m2_./n_m2_)
         end
     end
 
@@ -201,6 +218,13 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
         end
         @test_throws ErrorException evaluate(obj1)
         @test @compat(supertype)(typeof(obj1)) == Dolo.AbstractDoloFunctor
+
+        # the transition equations were given in the wrong order. Check that
+        # we throw an error here
+        @test_throws ErrorException Dolo.compile_equation(sm, :transition)
+
+        # we specified one expecation variable, but two expectation eqns
+        @test_throws ErrorException Dolo.compile_equation(sm, :expectation)
 
         obj2 = let
             eval(Dolo, Dolo.compile_equation(sm, :auxiliary))
@@ -235,6 +259,25 @@ Dolo.model_type(::MockSymbolic) = :dtcscc
         # test non-allocating version
         @inferred evaluate!(obj2, s, x, p, out)
         @test out == want
+
+        # test vectorized version
+        out_mat = zeros(5, 4)
+        want_mat = [want want want want want]'
+        @test @inferred(evaluate(obj2, [s s s s s]', x, p)) == want_mat
+        @test @inferred(evaluate(obj2, s, [x x x x x]', p)) == want_mat
+
+        # non-allocating vectorized version
+        @inferred evaluate!(obj2, s, [x x x x x]', p, out_mat)
+        @test out_mat == want_mat
+
+        # non-allocating vectorized version
+        @inferred evaluate!(obj2, [s s s s s]', x, p, out_mat)
+        @test out_mat == want_mat
+
+        # test errors for wrong size of out
+        @test_throws DimensionMismatch evaluate!(obj2, s, x, p, zeros(3))
+        @test_throws DimensionMismatch evaluate!(obj2, s, x, p, zeros(5))
+        @test_throws DimensionMismatch evaluate!(obj2, [s s s]', x, p, zeros(2, 4))
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,10 @@ else
     const Test = BaseTestNext
 end
 
-include("numeric.jl")
-include("parser.jl")
-include("util.jl")
-include("model_types.jl")
+tests = length(ARGS) > 0 ? ARGS : ["numeric",
+                                   "parser",
+                                   "util",
+                                   "model_types"]
+for t in tests
+    include("$(t).jl")
+end


### PR DESCRIPTION
The goal of this PR is to allow us to do vectorized evaluation of the model functions. The implementation allows a mix between some arguments being vectors (single points for each variable) and other arguments being matrices (multiple points for each variable).

This required some significant changes to the parser/compiler, including:

- swapping all arithmetic operators `+`, `-`, `*` `/`, and `^` for their element wise counterparts: `.+`, `.-`, `.*` `./`, and `.^`. This will have no performance hit on single point evaluation because those methods on scalars are lowered/compiled to the original non-elementwise operator
- We now have functions for unpacking function arguments. This allowed me to `@inline` a very simple function that dispatches on the type of the argument to either extract an element of an input vector (for single point evaluation) or a whole column of the input matrix (for vectorized evaluation).
- Similar point for the output argument to each function. We `@inline`d a simple function to set one element at a time for Vector output and one column at a time for matrix output.
- We now check the sizes of the output array to make sure the size conforms, given the arguments
- We check that all AbstractMatrix arguments have the same number of observations. 
- Removed `@inbounds` from the unpacking statements. we don't check the the sizes are correct, so we can't really guarantee that `@inbounds` is allowed
- For functions with a target, we now check that the order of equations is consistent with the declaration order of the variables
- I cleaned up the generated code a bit to make it more readable. We don't have quite as many `begin...end` blocks.


I also fixed the `print_code` keyword arg when constructing the numeric models and added that as a keyword argument to `yam_import`

The convention I adopted, which I believe is what we settled on for `TaylorExpansion`, is that in a Matrix argument or output, a column would represent all observations of a single variable. If this isn't correct let me know