### PR TITLE
Yaml tags

### DIFF
--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -10,6 +10,7 @@ using NLsolve
 using QuantEcon
 using Distributions: MvNormal
 import ForwardDiff
+import YAML
 
 export AbstractModel, AbstractSymbolicModel, AbstractNumericModel, ASM, ANM,
        SymbolicModel, DTCSCCModel, DTMSCCModel,

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -201,11 +201,20 @@ end
 
 eval_with(mc::ModelCalibration, s::AbstractString) = eval_with(mc, _to_expr(s))
 eval_with(mc::ModelCalibration, s::Symbol) = _replace_me(mc, s)
-eval_with(mc::ModelCalibration, d::Associative) =
-    Dict{Symbol,Any}([(symbol(k), eval_with(mc, v)) for (k, v) in d])
 eval_with(mc::ModelCalibration, x::Number) = x
 eval_with(mc::ModelCalibration, x::AbstractArray) = map(y->eval_with(mc, y), x)
-
+function eval_with(mc::ModelCalibration, d::Associative)
+    out = Dict{Symbol,Any}()
+    for (k, v) in d
+        sk = symbol(k)
+        if sk == :kind
+            out[sk] = v
+        else
+            out[sk] = eval_with(mc, v)
+        end
+    end
+    out
+end
 
 # function convert
 _to_Float64(x::Number) = convert(Float64, x)

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -215,9 +215,3 @@ function eval_with(mc::ModelCalibration, d::Associative)
     end
     out
 end
-
-# function convert
-_to_Float64(x::Number) = convert(Float64, x)
-_to_Float64(x::AbstractArray) = map(Float64, x)
-_to_Float64(d::Associative) =
-    Dict{Symbol,Any}([(symbol(k), _to_Float64(v)) for (k, v) in d])

--- a/src/model_import.jl
+++ b/src/model_import.jl
@@ -1,3 +1,11 @@
+Normal(;sigma=zeros(0, 0)) = Normal(sigma)
+Cartesian(;a=[], b=[], orders=[]) = Cartesian(a, b, orders)
+
+function construct_type_map(t::Symbol, constructor::YAML.Constructor, node::YAML.Node)
+    mapping = _symbol_dict(YAML.construct_mapping(constructor, node))
+    mapping[:kind] = t
+    mapping
+end
 
 function guess_model_type(data)
     if ("shocks" in keys(data["symbols"]))
@@ -13,12 +21,15 @@ end
 
 function yaml_import(url; print_code::Bool=false)
 
+    funcs = Dict("!Cartesian" => (c, n) -> construct_type_map(:Cartesian, c, n),
+                 "!Normal" => (c, n) -> construct_type_map(:Normal, c, n))
+
     if match(r"(http|https):.*", url) != nothing
         res = get(url)
         buf = IOBuffer(res.data)
-        data = load(buf)
+        data = load(buf, funcs)
     else
-        data = load_file(url)
+        data = load_file(url, funcs)
     end
 
     fname = basename(url)

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -1,52 +1,10 @@
-# ------------------- #
-# Numeric model types #
-# ------------------- #
-immutable Options
-    distribution
-    grid
-    other::Dict{Symbol,Any}  # TODO: shouldn't need. Just keeps stuff around
-end
+# ---------- #
+# Grid types #
+# ---------- #
 
-Options(;grid=nothing, distribution=nothing, other=Dict{Symbol,Any}()) =
-    Options(grid, distribution, other)
+abstract AbstractGrid
 
-
-function Options(sm::AbstractSymbolicModel, calib::ModelCalibration)
-    # numericize options
-    _options = eval_with(calib, deepcopy(sm.options))
-
-    _opts = Dict{Symbol,Any}()
-    other = Dict{Symbol,Any}()
-
-    # now construct Options object
-    for k in keys(_options)
-        data = pop!(_options, k)
-        if k == :grid
-            if data[:kind] == :Cartesian
-                _opts[:grid] = Cartesian(data)
-            else
-                m = "don't know how to handle grid of type $(data[:kind])"
-                error(m)
-            end
-        elseif k == :distribution
-            if data[:kind] == :Normal
-                n = length(calib[:shocks])
-                sigma = reshape(vcat(data[:sigma]...), n, n)
-                _opts[k] = Normal(_to_Float64(sigma))
-
-            else
-                m = "don't know how to handle distribution of type $(data[:kind])"
-                error(m)
-            end
-        else
-            other[k] = data
-        end
-    end
-
-    Options(;_opts..., other=other)
-end
-
-immutable Cartesian
+immutable Cartesian <: AbstractGrid
     a::Vector{Float64}
     b::Vector{Float64}
     orders::Vector{Int}
@@ -61,8 +19,70 @@ function Cartesian(stuff::Associative)
     Cartesian(stuff[:a], stuff[:b], stuff[:orders])
 end
 
-immutable Normal
+function _build_grid(data::Associative)
+    if data[:kind] == :Cartesian
+        return Cartesian(data)
+    else
+        m = "don't know how to handle grid of type $(data[:kind])"
+        error(m)
+    end
+end
+
+# ------------------ #
+# Distribution types #
+# ------------------ #
+
+abstract AbstractDistribution
+
+immutable Normal <: AbstractDistribution
     sigma::Matrix{Float64}
+end
+
+function _build_dist(data::Associative, calib::ModelCalibration)
+    if data[:kind] == :Normal
+        n = length(calib[:shocks])
+        sigma = reshape(vcat(data[:sigma]...), n, n)
+        return Normal(_to_Float64(sigma))
+    else
+        m = "don't know how to handle distribution of type $(data[:kind])"
+        error(m)
+    end
+end
+
+
+# ------------------- #
+# Numeric model types #
+# ------------------- #
+
+immutable Options{TD<:AbstractDistribution, TG<:AbstractGrid}
+    grid::TG
+    distribution::TD
+    other::Dict{Symbol,Any}  # TODO: shouldn't need. Just keeps stuff around
+end
+
+Options(;grid=nothing, distribution=nothing, other=Dict{Symbol,Any}()) =
+    Options(grid, distribution, other)
+
+function Options(sm::AbstractSymbolicModel, calib::ModelCalibration)
+    # numericize options
+    _options = eval_with(calib, deepcopy(sm.options))
+
+    _opts = Dict{Symbol,Any}()
+    other = Dict{Symbol,Any}()
+
+    # now construct Options object
+    for k in keys(_options)
+        data = pop!(_options, k)
+        if k == :grid
+            _opts[:grid] = _build_grid(data)
+        elseif k == :distribution
+            _opts[:distribution] = _build_dist(data, calib)
+        else
+            other[k] = data
+        end
+    end
+
+    Options(;_opts..., other=other)
 end
 
 immutable DTCSCCModel{ID} <: ANM{ID,:dtcscc}

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -1,11 +1,74 @@
 # ------------------- #
 # Numeric model types #
 # ------------------- #
+immutable Options
+    distribution
+    grid
+    other::Dict{Symbol,Any}  # TODO: shouldn't need. Just keeps stuff around
+end
+
+Options(;grid=nothing, distribution=nothing, other=Dict{Symbol,Any}()) =
+    Options(grid, distribution, other)
+
+
+function Options(sm::AbstractSymbolicModel, calib::ModelCalibration)
+    # numericize options
+    _options = eval_with(calib, deepcopy(sm.options))
+
+    _opts = Dict{Symbol,Any}()
+    other = Dict{Symbol,Any}()
+
+    # now construct Options object
+    for k in keys(_options)
+        data = pop!(_options, k)
+        if k == :grid
+            if data[:kind] == :Cartesian
+                _opts[:grid] = Cartesian(data)
+            else
+                m = "don't know how to handle grid of type $(data[:kind])"
+                error(m)
+            end
+        elseif k == :distribution
+            if data[:kind] == :Normal
+                n = length(calib[:shocks])
+                sigma = reshape(vcat(data[:sigma]...), n, n)
+                _opts[k] = Normal(_to_Float64(sigma))
+
+            else
+                m = "don't know how to handle distribution of type $(data[:kind])"
+                error(m)
+            end
+        else
+            other[k] = data
+        end
+    end
+
+    Options(;_opts..., other=other)
+end
+
+immutable Cartesian
+    a::Vector{Float64}
+    b::Vector{Float64}
+    orders::Vector{Int}
+end
+
+function Cartesian(stuff::Associative)
+    kind = get(stuff, :kind, nothing)
+    if kind != :Cartesian
+        error("Can't build Cartesian from dict with kind $(kind)")
+    end
+
+    Cartesian(stuff[:a], stuff[:b], stuff[:orders])
+end
+
+immutable Normal
+    sigma::Matrix{Float64}
+end
+
 immutable DTCSCCModel{ID} <: ANM{ID,:dtcscc}
     symbolic::ASM
     calibration::ModelCalibration
-    options::Dict{Symbol,Any}
-    distribution::Dict{Symbol,Any}
+    options::Options
     model_type::Symbol
     name::UTF8String
     filename::UTF8String
@@ -14,8 +77,7 @@ end
 immutable DTMSCCModel{ID} <: ANM{ID,:dtmscc}
     symbolic::ASM
     calibration::ModelCalibration
-    options::Dict{Symbol,Any}
-    distribution::Dict{Symbol,Any}
+    options::Options
     model_type::Symbol
     name::UTF8String
     filename::UTF8String
@@ -34,19 +96,13 @@ for TM in (:DTCSCCModel, :DTMSCCModel)
             for eqn in keys(sm.equations)
                 eval(Dolo, compile_equation(sm, eqn; print_code=print_code))
             end
+
+            # get numerical calibration and options
             calib = ModelCalibration(sm)
-            options = _to_Float64(eval_with(calib, deepcopy(sm.options)))
+            options = Options(sm, calib)
 
-            # hack to parse normal transition matrix into a matrix instead of
-            # a vector of vectors
-            dist = eval_with(calib, deepcopy(sm.distribution))
-            if haskey(dist, :Normal)
-                n = length(calib[:shocks])
-                dist[:Normal] = reshape(vcat(dist[:Normal]...), n, n)
-            end
 
-            dist = _to_Float64(dist)
-            $(TM){ID}(sm, calib, options, dist, sm.model_type,
+            $(TM){ID}(sm, calib, options, sm.model_type,
                       sm.name, sm.filename)
         end
     end

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -3,14 +3,13 @@ immutable SymbolicModel{ID,kind} <: ASM{ID,kind}
     equations::OrderedDict{Symbol,Vector{Expr}}
     calibration::OrderedDict{Symbol,Union{Expr,Symbol,Number}}
     options::Dict{Symbol,Any}
-    distribution::Dict{Symbol,Any}
     model_type::Symbol
     name::UTF8String
     filename::UTF8String
 
     function SymbolicModel(recipe::Associative, symbols::Associative,
                            eqs::Associative, calib::Associative,
-                           options::Associative, dist::Associative,
+                           options::Associative,
                            name="modeldoesnotwork", filename="none")
         # prep symbols
         model_type = symbol(recipe[:model_spec])
@@ -56,7 +55,7 @@ immutable SymbolicModel{ID,kind} <: ASM{ID,kind}
             end
         end
 
-        new(_symbols, _eqs, _calib, options, dist, model_type, name, filename)
+        new(_symbols, _eqs, _calib, options, model_type, name, filename)
     end
 end
 
@@ -79,12 +78,10 @@ function SymbolicModel(from_yaml::Dict, model_type::Symbol, filename="none")
     name = pop!(d, "name", "modeldoesnotwork")
     id = gensym(name)
     options = _symbol_dict(pop!(d, "options", Dict()))
-    distribution = _symbol_dict(pop!(d, "distribution", Dict()))
     out = SymbolicModel{id,model_type}(recipe, pop!(d, "symbols"),
                                        pop!(d, "equations"),
                                        pop!(d, "calibration"),
                                        options,
-                                       distribution,
                                        name,
                                        filename)
 


### PR DESCRIPTION
This does a few things:

- Together with [this commit of YAML.jl](https://github.com/spencerlyon2/YAML.jl/commit/d9cf218f68c42822a39a8a3ad4319d801f8dfafe) we can now handle the tags in the YAML file and build out the objects defined there. I think the fix on the YAML.jl side is kinda hacky and we should probably come up with a better way to allow this functionality. When (if) we do that we will need to revise here.
- I've moved the distribution settings back inside options as in dolo.py. This means it is no longer a field on `DTCSCCModel` and `DTMSCCModel`.
- Added types for the grid and distribution options as well as an Options type. `sm.options` will still be a dict for `sm <: SymbolicModel`. `m.options` is now an instance of `Options` for all the `m <: AbstractNumericModel`we define here.