### PR TITLE
ADD: documentation to algorithms

### DIFF
--- a/src/algos/steady_state.jl
+++ b/src/algos/steady_state.jl
@@ -1,3 +1,12 @@
+"""
+Computes the steady state of a model for a user-defined calibration.
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `calibration::OrderedDict`: Contains the model calibration.
+# Returns
+* `residuals::Dict`: Contains the residuals of the arbitrage equations, and the residuals of the transition equations.
+"""
 function steady_state_residuals(model, calibration)
     m = calibration[:exogenous]
     s = calibration[:states]
@@ -8,6 +17,10 @@ function steady_state_residuals(model, calibration)
     return Dict(:arbitrage=>res,:transition=>S-s)
 end
 
+
+"""
+Computes the steady state of a model, where the calibration is provided by the model object.
+"""
 function steady_state_residuals(model)
     return steady_state_residuals(model, model.calibration)
 end

--- a/src/algos/steady_state.jl
+++ b/src/algos/steady_state.jl
@@ -1,5 +1,7 @@
 """
-Computes the steady state of a model for a user-defined calibration.
+Computes the residuals of the arbitrage and transition equations at the steady state of the model.
+
+If the calibration for the model is not explicitly provided, the calibration is that associated with the model object.
 
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
@@ -18,9 +20,6 @@ function steady_state_residuals(model, calibration)
 end
 
 
-"""
-Computes the steady state of a model, where the calibration is provided by the model object.
-"""
 function steady_state_residuals(model)
     return steady_state_residuals(model, model.calibration)
 end

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -7,15 +7,18 @@ Computes the residuals of the arbitrage equations. The general form of the arbit
 where `m` are current exogenous variables, `s` are current states,
 `x` are current controls, `M` are next period's exogenous variables, `S` are next period's states, `X` are next period's controls, and `p` are the model parameters. This function evaluates the right hand side of the arbitrage equation for the given inputs.
 
+If the list of current controls `x` is provided as a two-dimensional array (`ListOfPoints`), it is transformed to a one-dimensional array (`ListOfListOfPoints`).
+
+
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
-* `dprocess::`: Discretized exogenous process.
-* `s::Vector{Float64}`: Current state variables.
-* `x::Array{Array{Float64,2},1}`: Current control variables.
+* `dprocess`: Discretized exogenous process.
+* `s::ListOfPoints`: List of state variable values.
+* `x::ListOfListOfPoints`: List of control variable values associated with each exogenous shock.
 * `p::Vector{Float64}`: Model parameters.
-* `dr::`: Current guess for the decision rule.
+* `dr`: Current guess for the decision rule.
 # Returns
-* `res::`: Residuals of the arbitrage equation.
+* `res`: Residuals of the arbitrage equation associated with each exogenous shock.
 """
 function residual(model, dprocess, s, x::Array{Array{Float64,2},1}, p, dr)
     N = size(s,1)
@@ -42,11 +45,7 @@ end
 
 using NLsolve
 
-"""
-Computes the residuals of the arbitrage equations.
 
-Reformats the current controls, `x`, if they are provided as a two-dimensional array.
-"""
 function residual(model, dprocess, s, x::Array{Float64,2}, p, dr)
     n_m = max(1,n_nodes(dprocess))
     xx = destack(x,n_m)
@@ -74,15 +73,17 @@ end
 
 
 """
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied to the residuals of the arbitrage equations.
+Computes a global solution for a model via backward time iteration. The time iteration is applied to the residuals of the arbitrage equations.
+
+If the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
+If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`
 
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
-* `process::`: The stochastic process associated with the exogenous variables in the model.
-* `init_dr::`: Initial guess for the decision rule.
+* `process`: The stochastic process associated with the exogenous variables in the model.
+* `init_dr`: Initial guess for the decision rule.
 # Returns
-* `dr::`: Solved decision rule.
+* `dr`: Solved decision rule.
 """
 function time_iteration(model, process, init_dr; verbose=true, maxit=100, tol=1e-8)
 
@@ -158,37 +159,18 @@ end
 
 
 # get stupid initial rule
-"""
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied to the residuals of the arbitrage equations.
-
-If the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
-"""
 function time_iteration(model, process::AbstractExogenous; kwargs...)
     init_dr = ConstantDecisionRule(model.calibration[:controls])
     return time_iteration(model, process, init_dr;  kwargs...)
 end
 
 
-"""
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied to the residuals of the arbitrage equations.
-
-If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`
-"""
 function time_iteration(model, init_dr::AbstractDecisionRule; kwargs...)
     process = model.exogenous
     return time_iteration(model, process, init_dr; kwargs...)
 end
 
 
-"""
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied to the residuals of the arbitrage equations.
-
-If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`.
-Additionally, if the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
-"""
 function time_iteration(model; kwargs...)
     process = model.exogenous
     init_dr = ConstantDecisionRule(model.calibration[:controls])

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -1,3 +1,22 @@
+
+"""
+Computes the residuals of the arbitrage equations. The general form of the arbitrage equation is
+
+    `0 = E_t [f(m, s, x, M, S, X; p)]`
+
+where `m` are current exogenous variables, `s` are current states,
+`x` are current controls, `M` are next period's exogenous variables, `S` are next period's states, `X` are next period's controls, and `p` are the model parameters. This function evaluates the right hand side of the arbitrage equation for the given inputs.
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `dprocess::`: Discretized exogenous process.
+* `s::Vector{Float64}`: Current state variables.
+* `x::Array{Array{Float64,2},1}`: Current control variables.
+* `p::Vector{Float64}`: Model parameters.
+* `dr::`: Current guess for the decision rule.
+# Returns
+* `res::`: Residuals of the arbitrage equation.
+"""
 function residual(model, dprocess, s, x::Array{Array{Float64,2},1}, p, dr)
     N = size(s,1)
     res = [zeros(size(x[1])) for i=1:length(x)]
@@ -23,7 +42,11 @@ end
 
 using NLsolve
 
+"""
+Computes the residuals of the arbitrage equations.
 
+Reformats the current controls, `x`, if they are provided as a two-dimensional array.
+"""
 function residual(model, dprocess, s, x::Array{Float64,2}, p, dr)
     n_m = max(1,n_nodes(dprocess))
     xx = destack(x,n_m)
@@ -31,17 +54,36 @@ function residual(model, dprocess, s, x::Array{Float64,2}, p, dr)
     return stack(res)
 end
 
+
+"""
+#TODO
+"""
 function destack(x::Array{Float64,2},n_m::Int)
     N = div(size(x,1),n_m)
     xx = reshape(x,N,n_m,size(x,2))
     return Array{Float64,2}[xx[:,i,:] for i=1:n_m]
 end
 
+
+"""
+#TODO
+"""
 function stack(x::Array{Array{Float64,2},1})
      return cat(1,x...)
 end
 
 
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied to the residuals of the arbitrage equations.
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `process::`: The stochastic process associated with the exogenous variables in the model.
+* `init_dr::`: Initial guess for the decision rule.
+# Returns
+* `dr::`: Solved decision rule.
+"""
 function time_iteration(model, process, init_dr; verbose=true, maxit=100, tol=1e-8)
 
     # get grid for endogenous
@@ -114,17 +156,39 @@ function time_iteration(model, process, init_dr; verbose=true, maxit=100, tol=1e
 
 end
 
+
 # get stupid initial rule
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied to the residuals of the arbitrage equations.
+
+If the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
+"""
 function time_iteration(model, process::AbstractExogenous; kwargs...)
     init_dr = ConstantDecisionRule(model.calibration[:controls])
     return time_iteration(model, process, init_dr;  kwargs...)
 end
 
+
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied to the residuals of the arbitrage equations.
+
+If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`
+"""
 function time_iteration(model, init_dr::AbstractDecisionRule; kwargs...)
     process = model.exogenous
     return time_iteration(model, process, init_dr; kwargs...)
 end
 
+
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied to the residuals of the arbitrage equations.
+
+If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`.
+Additionally, if the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
+"""
 function time_iteration(model; kwargs...)
     process = model.exogenous
     init_dr = ConstantDecisionRule(model.calibration[:controls])

--- a/src/algos/time_iteration_direct.jl
+++ b/src/algos/time_iteration_direct.jl
@@ -5,12 +5,15 @@ import Dolo
 Computes a global solution for a model via backward time iteration.
 The time iteration is  applied directly to the decision rule of the model.
 
+If the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
+If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`.
+
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
-* `process::`: The stochastic process associated with the exogenous variables in the model.
-* `init_dr::`: Initial guess for the decision rule.
+* `process`: The stochastic process associated with the exogenous variables in the model.
+* `init_dr`: Initial guess for the decision rule.
 # Returns
-* `dr::`: Solved decision rule.
+* `dr`: Solved decision rule.
 """
 function time_iteration_direct(model, process, init_dr; verbose=true, maxit=100, tol=1e-8)
 
@@ -102,36 +105,18 @@ function time_iteration_direct(model, process, init_dr; verbose=true, maxit=100,
 end
 
 
-"""
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied directly to the decision rule of the model.
-
-If the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
-"""
 function time_iteration_direct(model, process::AbstractExogenous; kwargs...)
     init_dr = ConstantDecisionRule(model.calibration[:controls])
     return time_iteration_direct(model, process, init_dr; kwargs...)
 end
 
 
-"""
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied directly to the decision rule of the model.
-
-If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`
-"""
 function time_iteration_direct(model, init_dr::AbstractDecisionRule; kwargs...)
     process = model.exogenous
     return time_iteration_direct(model, process, init_dr; kwargs...)
 end
 
-"""
-Computes a global solution for a model via backward time iteration.
-The time iteration is applied directly to the decision rule of the model.
 
-If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`.
-Additionally, if the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
-"""
 function time_iteration_direct(model; kwargs...)
     process = model.exogenous
     init_dr = ConstantDecisionRule(model.calibration[:controls])

--- a/src/algos/time_iteration_direct.jl
+++ b/src/algos/time_iteration_direct.jl
@@ -1,5 +1,17 @@
 import Dolo
 
+
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is  applied directly to the decision rule of the model.
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `process::`: The stochastic process associated with the exogenous variables in the model.
+* `init_dr::`: Initial guess for the decision rule.
+# Returns
+* `dr::`: Solved decision rule.
+"""
 function time_iteration_direct(model, process, init_dr; verbose=true, maxit=100, tol=1e-8)
 
   # Grid
@@ -90,18 +102,36 @@ function time_iteration_direct(model, process, init_dr; verbose=true, maxit=100,
 end
 
 
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied directly to the decision rule of the model.
+
+If the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
+"""
 function time_iteration_direct(model, process::AbstractExogenous; kwargs...)
     init_dr = ConstantDecisionRule(model.calibration[:controls])
     return time_iteration_direct(model, process, init_dr; kwargs...)
 end
 
 
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied directly to the decision rule of the model.
+
+If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`
+"""
 function time_iteration_direct(model, init_dr::AbstractDecisionRule; kwargs...)
     process = model.exogenous
     return time_iteration_direct(model, process, init_dr; kwargs...)
 end
 
+"""
+Computes a global solution for a model via backward time iteration.
+The time iteration is applied directly to the decision rule of the model.
 
+If the stochastic process for the model is not explicitly provided, the process is taken from the default provided by the model object, `model.exogenous`.
+Additionally, if the initial guess for the decision rule is not explicitly provided, the initial guess is provided by `ConstantDecisionRule`.
+"""
 function time_iteration_direct(model; kwargs...)
     process = model.exogenous
     init_dr = ConstantDecisionRule(model.calibration[:controls])

--- a/src/algos/value_iteration.jl
+++ b/src/algos/value_iteration.jl
@@ -1,5 +1,17 @@
 using Optim
 
+
+"""
+#TODO: Is evaluate_policy the best name for this? Seems that we are evaluating the value function, or evaluating a current decision rule.
+
+Evaluate the value function under the given decision rule, `dr` (i.e. evaluating under the current guess for the policy function). Then, using the evaluated value function, construct a new interpolation object for the value function.
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `dr::`: Current guess for the decision rule.
+# Returns
+* `drv::`: Value function.
+"""
 function evaluate_policy(model, dr; verbose=true, maxit=100, )
 
     β = model.calibration.flat[:beta]
@@ -91,7 +103,23 @@ function evaluate_policy(model, dr; verbose=true, maxit=100, )
 end
 
 
+"""
+Evaluate a value function object `drv` at a particular combination of values for states, controls, and exogenous variable(s).
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `β::Float64`: Value of the discount factor.
+* `dprocess::`: Discretized exogenous process.
+* `drv::`: Current guess for the value function object.
+* `i::Int64`: Index of node for exogeous variable(s).
+* `s::Vector{Float64}`: Current state variables.
+* `x::Vector{Float64}`: Current control variables.
+* `p::Vector{Float64}`: Model parameters.
+# Returns
+* `E_V::`: Evaluated value function.
+"""
 function update_value(model, β::Float64, dprocess, drv, i, s::Vector{Float64}, x0::Vector{Float64}, p::Vector{Float64})
+
     m = node(dprocess,i)  ::Vector{Float64}
     E_V = 0.0
     for j=1:n_inodes(dprocess,i)
@@ -105,6 +133,17 @@ function update_value(model, β::Float64, dprocess, drv, i, s::Vector{Float64}, 
     return E_V
 end
 
+
+"""
+Solve for the value function and associated decision rule using value function iteration.
+
+# Arguments
+* `model::NumericModel`: Model object that describes the current model environment.
+* `dr::`: Initial guess for the decision rule.
+# Returns
+* `dr::`: Solved decision rule object.
+* `drv::`: Solved value function object.
+"""
 function solve_policy(model, dr; verbose=true, maxit=5000, )
 
     β = model.calibration.flat[:beta]

--- a/src/algos/value_iteration.jl
+++ b/src/algos/value_iteration.jl
@@ -2,15 +2,13 @@ using Optim
 
 
 """
-#TODO: Is evaluate_policy the best name for this? Seems that we are evaluating the value function, or evaluating a current decision rule.
-
-Evaluate the value function under the given decision rule, `dr` (i.e. evaluating under the current guess for the policy function). Then, using the evaluated value function, construct a new interpolation object for the value function.
+Evaluate the value function under the given decision rule.
 
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
-* `dr::`: Current guess for the decision rule.
+* `dr`: Current guess for the decision rule.
 # Returns
-* `drv::`: Value function.
+* `drv`: Value function.
 """
 function evaluate_policy(model, dr; verbose=true, maxit=100, )
 
@@ -104,19 +102,19 @@ end
 
 
 """
-Evaluate a value function object `drv` at a particular combination of values for states, controls, and exogenous variable(s).
+Evaluate the right hand side of the value function at given values of states, controls, and exogenous variables.
 
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
 * `β::Float64`: Value of the discount factor.
 * `dprocess::`: Discretized exogenous process.
-* `drv::`: Current guess for the value function object.
+* `drv`: Current guess for the value function object.
 * `i::Int64`: Index of node for exogeous variable(s).
-* `s::Vector{Float64}`: Current state variables.
-* `x::Vector{Float64}`: Current control variables.
+* `s::ListOfPoints`: List of state variables.
+* `x0::ListOfListOfPoints`: List of control variables.
 * `p::Vector{Float64}`: Model parameters.
 # Returns
-* `E_V::`: Evaluated value function.
+* `E_V::`: Right hand side of the value function.
 """
 function update_value(model, β::Float64, dprocess, drv, i, s::Vector{Float64}, x0::Vector{Float64}, p::Vector{Float64})
 
@@ -139,10 +137,10 @@ Solve for the value function and associated decision rule using value function i
 
 # Arguments
 * `model::NumericModel`: Model object that describes the current model environment.
-* `dr::`: Initial guess for the decision rule.
+* `dr`: Initial guess for the decision rule.
 # Returns
-* `dr::`: Solved decision rule object.
-* `drv::`: Solved value function object.
+* `dr`: Solved decision rule object.
+* `drv`: Solved value function object.
 """
 function solve_policy(model, dr; verbose=true, maxit=5000, )
 


### PR DESCRIPTION
Added documentation for:

- steady_state.jl
- time_iteration_direct.jl
- time_iteration.jl
- value_iteration.jl

One quick question I have about function names: inside value_iteration.jl, there is a function `evaluate_policy`, which actually seems to be evaluating and returning the value function for a given decision rule. Could we possibly have a better name that `evaluate_policy`, since that's not actually what it's doing? No worries if not, just need to make the documentation explicit. 

Also, @albop in the [roadmap](https://github.com/EconForge/Dolo.jl/blob/master/ROADMAP.md), you mention that you want language independent documentation. At the moment, I have language dependent arguments, returns, and so on. Could you let me know what style you might want these in? E.g. what would the following become?:  `x::Vector{Float64}`: Current control variables