### PR TITLE
ENH: replace evaluate function with methods for call

### DIFF
--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -12,7 +12,7 @@ function residual(model, dprocess, s, x::Array{Array{Float64,2},1}, p, dr)
             for n=1:N
                 S[n,:] = Dolo.transition(model, m, s[n,:], x[i][n,:], M, p)
             end
-            X = evaluate(dr, i, j, S)
+            X = dr(i, j, S)
             for n=1:N
                 res[i][n,:] += w*Dolo.arbitrage(model, m, s[n,:], x[i][n,:], M, S[n,:], X[n,:], p)
             end
@@ -61,7 +61,7 @@ function time_iteration(model, process, init_dr; verbose=true, maxit=100, tol=1e
 
     p = model.calibration[:parameters] :: Vector{Float64}
 
-    x0 = [evaluate(init_dr, i, endo_nodes) for i=1:nsd]
+    x0 = [init_dr(i, endo_nodes) for i=1:nsd]
 
 
     x_lb = Array{Float64,2}[cat(1,[Dolo.controls_lb(model,node(dprocess,i) ,endo_nodes[n,:],p)' for n=1:N]...) for i=1:nsd]

--- a/src/algos/time_iteration_direct.jl
+++ b/src/algos/time_iteration_direct.jl
@@ -19,7 +19,7 @@ function time_iteration_direct(model, process, init_dr; verbose=true, maxit=100,
     return cat(1,x...)
   end
   # initial guess for controls
-  x0 = [evaluate(init_dr, i, endo_nodes) for i=1:nsd]
+  x0 = [init_dr(i, endo_nodes) for i=1:nsd]
   # set the bound for the controls to check during the iterations not to violate them
   x_lb = Array{Float64,2}[cat(1,[Dolo.controls_lb(model,node(dprocess,i) ,endo_nodes[n,:],p)' for n=1:N]...) for i=1:nsd]
   x_ub = Array{Float64,2}[cat(1,[Dolo.controls_ub(model,node(dprocess,i),endo_nodes[n,:],p)' for n=1:N]...) for i=1:nsd]
@@ -60,7 +60,7 @@ function time_iteration_direct(model, process, init_dr; verbose=true, maxit=100,
                 S[n,:] = Dolo.transition(model, m, s[n,:], x0[i][n,:], M, p)
             end
             # interpolate controles conditional states of tomorrow
-            X = evaluate(dr, i, j, S)
+            X = dr(i, j, S)
             # Compute expectations as a weited average of the exo states w_j
             for n=1:N
                 E_f[i][n,:] += w*Dolo.expectation(model, M, S[n,:], X[n,:], p)

--- a/src/numeric/decision_rules.jl
+++ b/src/numeric/decision_rules.jl
@@ -21,10 +21,10 @@ end
 type ConstantDecisionRule <: AbstractDecisionRule
     values::Array{Float64,1}
 end
-evaluate(dr::ConstantDecisionRule, x::Array{Float64,1}) = dr.values
-evaluate(dr::ConstantDecisionRule, x::Array{Float64,2}) = repmat(dr.values',size(x,1),1)
-evaluate(dr::ConstantDecisionRule, i::Int, x::Union{Vector,Matrix}) =  evaluate(dr, x)
-evaluate(dr::ConstantDecisionRule, i::Int, j::Int, x::Union{Vector, Matrix}) = evaluate(dr, x)
+(dr::ConstantDecisionRule)(x::Array{Float64,1}) = dr.values
+(dr::ConstantDecisionRule)(x::Array{Float64,2}) = repmat(dr.values',size(x,1),1)
+(dr::ConstantDecisionRule)(i::Int, x::Union{Vector,Matrix}) =  dr(x)
+(dr::ConstantDecisionRule)(i::Int, j::Int, x::Union{Vector, Matrix}) = dr(x)
 
 
 
@@ -63,7 +63,7 @@ function DecisionRule(mc::DiscreteMarkovProcess, grid::CartesianGrid, values::Ar
     return dr
 end
 
-function evaluate(dr::MCDecisionRule, i::Int, x::Array{Float64,2})
+function (dr::MCDecisionRule)(i::Int, x::Array{Float64,2})
     a = dr.grid.min
     b = dr.grid.max
     n = dr.grid.n
@@ -72,8 +72,8 @@ function evaluate(dr::MCDecisionRule, i::Int, x::Array{Float64,2})
     return res
 end
 
-evaluate(dr::MCDecisionRule, i::Int, x::Array{Float64,1}) =  evaluate(dr, i, x')[:]
-evaluate(dr::MCDecisionRule, i::Int, j::Int, x::Union{Vector, Matrix}) = evaluate(dr, j, x)
+(dr::MCDecisionRule)(i::Int, x::Array{Float64,1}) =  dr(i, x')[:]
+(dr::MCDecisionRule)(i::Int, j::Int, x::Union{Vector, Matrix}) = dr(j, x)
 
 
 # Decision Rule on IID Process
@@ -117,7 +117,7 @@ function DecisionRule(proc::MvNormal, grid::CartesianGrid, values::Array{Float64
     return DecisionRule(proc, grid, [values])
 end
 
-function evaluate(dr::IDecisionRule, x::Array{Float64,2})
+function (dr::IDecisionRule)(x::Array{Float64,2})
     a = dr.grid.min
     b = dr.grid.max
     n = dr.grid.n
@@ -125,10 +125,10 @@ function evaluate(dr::IDecisionRule, x::Array{Float64,2})
     res = splines.eval_UC_multi_spline(a,b,n,cc,x)'
     return res
 end
-evaluate(dr::IDecisionRule, x::Array{Float64,1}) = evaluate(dr, x')[:]
-evaluate(dr::IDecisionRule, i::Int, x::Array{Float64,2}) = evaluate(dr, x)
-evaluate(dr::IDecisionRule, i::Int, x::Array{Float64,1}) =  evaluate(dr, x)
-evaluate(dr::IDecisionRule, i::Int, j::Int, x::Union{Vector, Matrix}) = evaluate(dr, x)
+(dr::IDecisionRule)(x::Array{Float64,1}) = dr(x')[:]
+(dr::IDecisionRule)(i::Int, x::Array{Float64,2}) = dr(x)
+(dr::IDecisionRule)(i::Int, x::Array{Float64,1}) =  dr(x)
+(dr::IDecisionRule)(i::Int, j::Int, x::Union{Vector, Matrix}) = dr(x)
 
 
 
@@ -191,7 +191,7 @@ function DecisionRule(dp::DiscretizedProcess, grid::CartesianGrid, values::Array
     return dr
 end
 
-function evaluate(dr::CPDecisionRule, z::Array{Float64,2})
+function (dr::CPDecisionRule)(z::Array{Float64,2})
     a = dr.grid.min
     b = dr.grid.max
     n = dr.grid.n
@@ -200,10 +200,10 @@ function evaluate(dr::CPDecisionRule, z::Array{Float64,2})
     return res
 end
 
-evaluate(dr::CPDecisionRule, z::Vector) = evaluate(dr,z')[:]
+(dr::CPDecisionRule)(z::Vector) = dr(z')[:]
 
 
-function evaluate(dr::CPDecisionRule, i::Int64, x::Array{Float64,2})
+function (dr::CPDecisionRule)(i::Int64, x::Array{Float64,2})
     a = dr.grid.min
     b = dr.grid.max
     n = dr.grid.n
@@ -217,7 +217,7 @@ end
 
 
 
-function evaluate(dr::CPDecisionRule, i::Int64, j::Int64, x::Array{Float64,2})
+function (dr::CPDecisionRule)(i::Int64, j::Int64, x::Array{Float64,2})
     a = dr.grid.min
     b = dr.grid.max
     n = dr.grid.n
@@ -231,5 +231,5 @@ end
 
 
 
-evaluate(dr::CPDecisionRule, i::Int64, x::Vector) = evaluate(dr,i,x')[:]
-evaluate(dr::CPDecisionRule, i::Int64, j::Int64, x::Vector) = evaluate(dr,i,j,x')[:]
+(dr::CPDecisionRule)(i::Int64, x::Vector) = dr(i,x')[:]
+(dr::CPDecisionRule)(i::Int64, j::Int64, x::Vector) = dr(i,j,x')[:]

--- a/src/numeric/simulations.jl
+++ b/src/numeric/simulations.jl
@@ -53,20 +53,20 @@ function QuantEcon.simulate(m::AbstractNumericModel, dr::AbstractDecisionRule,
             epsilons = rand(ϵ_dist, n_exp)'
         end
 
-        s = slice(s_simul, :, :, t)
+        s = view(s_simul, :, :, t)
 
         # extract x and then fill it
-        x = slice(x_simul, :, :, t)
+        x = view(x_simul, :, :, t)
         dr(s, x)
 
         if has_aux
             # extract a and then fill it
-            y = slice(y_simul, :, :, t)
+            y = view(y_simul, :, :, t)
             evaluate!(a, s, x, params, y)
         end
 
         if t < horizon
-            ss = slice(s_simul, :, :, t+1)
+            ss = view(s_simul, :, :, t+1)
             evaluate!(g, s, x, epsilons, params, ss)
         end
     end

--- a/test/test_algos.jl
+++ b/test/test_algos.jl
@@ -1,11 +1,9 @@
 path = Pkg.dir("Dolo")
 
-Pkg.build("QuantEcon")
 import Dolo
 
-filename = joinpath(path,"examples","models","rbc_dtcc_mc.yaml")
-# filename = joinpath(path,"examples","models","sudden_stop.yaml")
-model_mc = Dolo.yaml_import(filename)
+fn = joinpath(path,"examples","models","rbc_dtcc_mc.yaml")
+model_mc = Dolo.yaml_import(fn)
 
 drc = Dolo.ConstantDecisionRule(model_mc.calibration[:controls])
 @time dr0, drv0 = Dolo.solve_policy(model_mc, drc, verbose=true, maxit=10000 )
@@ -18,17 +16,17 @@ drc = Dolo.ConstantDecisionRule(model_mc.calibration[:controls])
 
 # compare with prerecorded values
 kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
-nvec = [Dolo.evaluate(dr,1,[k])[1] for k in kvec]
-ivec = [Dolo.evaluate(dr,1,[k])[2] for k in kvec]
+nvec = [dr(1,[k])[1] for k in kvec]
+ivec = [dr(1,[k])[2] for k in kvec]
 # compare  time_iteration_direct
-nvec_d = [Dolo.evaluate(drd,1,[k])[1] for k in kvec]
-ivec_d = [Dolo.evaluate(drd,1,[k])[2] for k in kvec]
-@assert maximum(abs(nvec_d-nvec))<1e-
+nvec_d = [drd(1,[k])[1] for k in kvec]
+ivec_d = [drd(1,[k])[2] for k in kvec]
+@assert maxabs(nvec_d-nvec)<1e-4
 
 # compare  vfi
-nvec_0 = [Dolo.evaluate(dr0,1,[k])[1] for k in kvec]
-ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
-@assert maximum(abs(nvec_0-nvec))<1e-4
+nvec_0 = [dr0(1,[k])[1] for k in kvec]
+ivec_0 = [dr0(1,[k])[2] for k in kvec]
+@assert maxabs(nvec_0-nvec)<1e-4
 
 
 # let's redo when model is stable !
@@ -39,8 +37,8 @@ ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
 
 
 # this one needs a lower value of beta or a better initial guess
-filename = joinpath(path,"examples","models","rbc_dtcc_iid.yaml")
-model = Dolo.yaml_import(filename)
+fn = joinpath(path,"examples","models","rbc_dtcc_iid.yaml")
+model = Dolo.yaml_import(fn)
 
 drc = Dolo.ConstantDecisionRule(model.calibration[:controls])
 @time dr0, drv0 = Dolo.solve_policy(model, drc, verbose=true, maxit=1000 )
@@ -52,22 +50,22 @@ drc = Dolo.ConstantDecisionRule(model.calibration[:controls])
 @time drv = Dolo.evaluate_policy(model, dr, verbose=true)
 
 kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
-nvec = [Dolo.evaluate(dr,1,[k])[1] for k in kvec]
-ivec = [Dolo.evaluate(dr,1,[k])[2] for k in kvec]
-nvec_d = [Dolo.evaluate(drd,1,[k])[1] for k in kvec]
-ivec_d = [Dolo.evaluate(drd,1,[k])[2] for k in kvec]
-nvec_0 = [Dolo.evaluate(dr0,1,[k])[1] for k in kvec]
-ivec_0 = [Dolo.evaluate(dr0,1,[k])[2] for k in kvec]
+nvec = [dr(1,[k])[1] for k in kvec]
+ivec = [dr(1,[k])[2] for k in kvec]
+nvec_d = [drd(1,[k])[1] for k in kvec]
+ivec_d = [drd(1,[k])[2] for k in kvec]
+nvec_0 = [dr0(1,[k])[1] for k in kvec]
+ivec_0 = [dr0(1,[k])[2] for k in kvec]
 
-@assert maximum(abs(nvec_d-nvec))<1e-5
-@assert maximum(abs(nvec_0-nvec))<1e-5 # not satisfied right now (see tol. of optimizer)
+@assert maxabs(nvec_d-nvec)<1e-5
+@assert maxabs(nvec_0-nvec)<1e-5 # not satisfied right now (see tol. of optimizer)
 
 
 
 
 # does not work yet
-filename = joinpath(path,"examples","models","rbc_dtcc_ar1.yaml")
-model = Dolo.yaml_import(filename)
+fn = joinpath(path,"examples","models","rbc_dtcc_ar1.yaml")
+model = Dolo.yaml_import(fn)
 
 Dolo.discretize(model.exogenous)
 

--- a/test/test_decision_rules.jl
+++ b/test/test_decision_rules.jl
@@ -14,9 +14,9 @@ vv = [values for i=1:size(mc.values,1)]
 dr = DecisionRule(mc, grid, vv)
 set_values(dr,vv) # filter coefficients
 
-evaluate(dr, 1, [0.1 0.5])
+dr(1, [0.1 0.5])
 s0 = [0.2, 0.5]'
-res =  evaluate(dr, 1, s0)
+res =  dr(1, s0)
 
 
 grid = CartesianGrid([0.0,1.0], [0.1, 0.4], [5,4])
@@ -27,5 +27,5 @@ vv = [values]
 dr = DecisionRule(mvn, grid, vv)
 set_values(dr, values) # filter coefficients
 s0 = [0.2, 0.5]'
-res =  evaluate(dr, 1, s0)
-evaluate(dr, 1, [0.1 0.5])
+res =  dr(1, s0)
+dr(1, [0.1 0.5])

--- a/test/test_time_iteration.jl
+++ b/test/test_time_iteration.jl
@@ -28,8 +28,8 @@ steady_state(model, model.calibration)
 
 @time dr = time_iteration(model, process, verbose=true)
 
-ivals = [evaluate(dr, 1, [i])[1] for i=kvec ]
-nvals = [evaluate(dr, 1, [i])[2] for i=kvec ]
+ivals = [dr(1, [i])[1] for i=kvec ]
+nvals = [dr(1, [i])[2] for i=kvec ]
 
 
 using Gadfly
@@ -38,5 +38,5 @@ plot(x=kvec, y=ivals)
 
 plot(x=kvec, y=nvals)
 
-kkvec = [evaluate(dr,1,[k])[1] for k in kvec]
+kkvec = [dr(1,[k])[1] for k in kvec]
 plot(x=kvec, y=yvec, Geom.line)

--- a/test/test_value_iteration.jl
+++ b/test/test_value_iteration.jl
@@ -43,5 +43,5 @@ using Gadfly
 kvec = linspace(8,12,100)
 
 drv_answer.grid
-yvec = [evaluate(drv_answer,1,[k])[1] for k in kvec]
+yvec = [drv_answer(1,[k])[1] for k in kvec]
 plot(x=kvec, y=yvec, Geom.line)

--- a/test/test_vfi.jl
+++ b/test/test_vfi.jl
@@ -12,11 +12,11 @@ model
 val0 = Dolo.evaluate_policy(model, dr, maxit=5000)
 
 kvec = collect(linspace(5,30,10))
-vec0 = [Dolo.evaluate(val0, 1, [k])[1] for k in kvec]
+vec0 = [val0(1, [k])[1] for k in kvec]
 
-n_vec = [Dolo.evaluate(dr, 1, [k])[1] for k in kvec]
-i_vec = [Dolo.evaluate(dr, 1, [k])[2] for k in kvec]
-v_vec = [Dolo.evaluate(dr, 1, [k])[3] for k in kvec]
+n_vec = [dr(1, [k])[1] for k in kvec]
+i_vec = [dr(1, [k])[2] for k in kvec]
+v_vec = [dr(1, [k])[3] for k in kvec]
 
 v_vec
 
@@ -30,7 +30,7 @@ drv, controls = temp.solve_policy(model, dr)
 
 
 initial_x, lower, upper, drv = temp.solve_policy(model, dr)
-vec = [Dolo.evaluate(drv, 1, [k])[1] for k in kvec]
+vec = [drv(1, [k])[1] for k in kvec]
 
 
 using DataFrames
@@ -63,17 +63,17 @@ i = 1
 p = model.calibration[:parameters]
 x0
 
-evaluate(drv,i,x0)
+drv(i,x0)
 
 ivec = linspace(x0[2]*0.5,x0[2]*3)
 xvec = [[x0[1],xx] for xx in ivec]
 resp_vec = [temp.update_value(model, beta, dprocess, drv, i, s, xx, p) for xx in xvec]
 
-evaluate(drv,i,x0)
+drv(i,x0)
 
 l1 = layer(x=ivec,y=resp_vec,Geom.line)
 l2 = layer(xintercept=[x0[2]], Geom.vline)
-l3 = layer(yintercept=[evaluate(drv,i,x0)[1]], Geom.hline)
+l3 = layer(yintercept=[drv(i,x0)[1]], Geom.hline)
 
 plot(l1,l2,l3)
 


### PR DESCRIPTION
This Pr replaces the `evaluate` function with new methods for `Base.call`. So now instead of `evaluate(dr, args...)` we do `dr(args...)`