### PR TITLE
FIX: Array->AbstractArray in DecisionRules

### DIFF
--- a/src/algos/perturbation.jl
+++ b/src/algos/perturbation.jl
@@ -8,7 +8,7 @@ function get_ss_derivatives(model)
 end
 
 perturbate(p::IIDExogenous) = (zeros(0), zeros(0,0))
-perturbate(p::VAR1) = (p.M, p.R)
+perturbate(p::VAR1) = (p.mu, p.R)
 
 type PerturbationResult
     solution::BiTaylorExpansion

--- a/src/algos/simulation.jl
+++ b/src/algos/simulation.jl
@@ -21,18 +21,16 @@ function simulate(model::AbstractNumericModel, dr::AbstractDecisionRule,
     nx = length(x0)
     nsx = nx+ns
 
-    # TODO: talk to Pablo and make a decision about this
     s_simul = Array(Float64, N, ns, T)
     x_simul = Array(Float64, N, nx, T)
     for i in 1:N
       s_simul[i, :, 1] = s0
       x_simul[i, :, 1] = x0
     end
-    # NOTE: this will be empty if ny is zero. That's ok. Our call to `cat`  #       below will work either way  y_simul = Array(Float64, N, ny, horizon)
 
     for t in 1:T
-        s = copy(view(s_simul, :, :, t))
-        m = copy(view(epsilons, :, :, t))
+        s = view(s_simul, :, :, t)
+        m = view(epsilons, :, :, t)
         x = dr(m,s)
         x_simul[:, :, t] = x
         if t < T
@@ -120,8 +118,5 @@ import DataFrames
 function response(model::AbstractNumericModel,  dr::AbstractDecisionRule,
                   shock_name::Symbol; kwargs...)
     s0 = model.calibration[:states]
-    sims = simulate(model, dr, s0, e0; stochastic=false, n_exp=1, kwargs...)
-    sim = sims[1,:,:]
-    columns = cat(1, model.symbols[:exogenous], model.symbols[:states], model.symbols[:controls])
-    return DataFrames.DataFrame(Dict(columns[i]=>sim[i,:] for i=1:length(columns)))
+    return response(model, dr, s0, shock_name;  kwargs...)
 end

--- a/src/numeric/decision_rules.jl
+++ b/src/numeric/decision_rules.jl
@@ -19,14 +19,14 @@ type ConstantDecisionRule <: AbstractDecisionRule
     constants::Vector{Float64}
 end
 
-(dr::ConstantDecisionRule)(x::Vector{Float64}) = dr.constants
-(dr::ConstantDecisionRule)(x::Matrix{Float64}) = repmat(dr.constants',size(x,1),1)
-(dr::ConstantDecisionRule)(x::Vector{Float64}, y::Vector{Float64}) = dr.constants
-(dr::ConstantDecisionRule)(x::Vector{Float64}, y::Matrix{Float64}) = repmat( dr.constants', size(y,1), 1)
-(dr::ConstantDecisionRule)(x::Matrix{Float64}, y::Vector{Float64}) = repmat( dr.constants', size(x,1), 1)
-(dr::ConstantDecisionRule)(x::Matrix{Float64}, y::Matrix{Float64}) = repmat( dr.constants', size(x,1), 1)
-(dr::ConstantDecisionRule)(i::Int, x::Union{Vector{Float64},Matrix{Float64}}) = dr(x)
-(dr::ConstantDecisionRule)(i::Int, j::Int, x::Union{Vector{Float64},Matrix{Float64}}) = dr(x)
+(dr::ConstantDecisionRule)(x::AbstractVector{Float64}) = dr.constants
+(dr::ConstantDecisionRule)(x::AbstractMatrix{Float64}) = repmat(dr.constants',size(x,1),1)
+(dr::ConstantDecisionRule)(x::AbstractVector{Float64}, y::AbstractVector{Float64}) = dr.constants
+(dr::ConstantDecisionRule)(x::AbstractVector{Float64}, y::AbstractMatrix{Float64}) = repmat( dr.constants', size(y,1), 1)
+(dr::ConstantDecisionRule)(x::AbstractMatrix{Float64}, y::AbstractVector{Float64}) = repmat( dr.constants', size(x,1), 1)
+(dr::ConstantDecisionRule)(x::AbstractMatrix{Float64}, y::AbstractMatrix{Float64}) = repmat( dr.constants', size(x,1), 1)
+(dr::ConstantDecisionRule)(i::Int, x::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = dr(x)
+(dr::ConstantDecisionRule)(i::Int, j::Int, x::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = dr(x)
 
 
 type BiTaylorExpansion <: AbstractDecisionRule
@@ -37,10 +37,10 @@ type BiTaylorExpansion <: AbstractDecisionRule
     x_s::Matrix{Float64}
 end
 
-(dr::BiTaylorExpansion)(m::Vector{Float64}, s::Vector{Float64}) = dr.x0 + dr.x_m*(m-dr.m0) + dr.x_s*(s-dr.s0)
-(dr::BiTaylorExpansion)(m::Matrix{Float64}, s::Vector{Float64}) = vcat( [ (dr(m[i,:],s))' for i=1:size(m,1) ]...)
-(dr::BiTaylorExpansion)(m::Vector{Float64}, s::Matrix{Float64}) = vcat( [ (dr(m,s[i,:]))' for i=1:size(s,1) ]...)
-(dr::BiTaylorExpansion)(m::Matrix{Float64}, s::Matrix{Float64}) = vcat( [ (dr(m[i,:],s[i,:]))' for i=1:size(m,1) ]...)
+(dr::BiTaylorExpansion)(m::AbstractVector{Float64}, s::AbstractVector{Float64}) = dr.x0 + dr.x_m*(m-dr.m0) + dr.x_s*(s-dr.s0)
+(dr::BiTaylorExpansion)(m::AbstractMatrix{Float64}, s::AbstractVector{Float64}) = vcat( [ (dr(m[i,:],s))' for i=1:size(m,1) ]...)
+(dr::BiTaylorExpansion)(m::AbstractVector{Float64}, s::AbstractMatrix{Float64}) = vcat( [ (dr(m,s[i,:]))' for i=1:size(s,1) ]...)
+(dr::BiTaylorExpansion)(m::AbstractMatrix{Float64}, s::AbstractMatrix{Float64}) = vcat( [ (dr(m[i,:],s[i,:]))' for i=1:size(m,1) ]...)
 
 
 function filter_mcoeffs(a::Array{Float64,1},b::Array{Float64,1},n::Array{Int,1},mvalues::Array{Float64})
@@ -87,7 +87,7 @@ function set_values!(dr::AbstractDecisionRule{EmptyGrid, CartesianGrid}, values:
     set_values!(dr, [values])
 end
 
-function evaluate(dr::AbstractDecisionRule{EmptyGrid, CartesianGrid},z::Matrix{Float64})
+function evaluate(dr::AbstractDecisionRule{EmptyGrid, CartesianGrid},z::AbstractMatrix{Float64})
     a = dr.grid_endo.min
     b = dr.grid_endo.max
     n = dr.grid_endo.n
@@ -96,10 +96,10 @@ function evaluate(dr::AbstractDecisionRule{EmptyGrid, CartesianGrid},z::Matrix{F
     return res
 end
 
-(dr::DecisionRule{EmptyGrid, CartesianGrid})(z::Matrix{Float64}) = evaluate(dr,z)
-(dr::DecisionRule{EmptyGrid, CartesianGrid})(z::Vector{Float64}) = dr(z')[:]
-(dr::DecisionRule{EmptyGrid, CartesianGrid})(i::Int, x::Union{Vector{Float64},Matrix{Float64}}) = dr(x)
-(dr::DecisionRule{EmptyGrid, CartesianGrid})(x::Union{Vector{Float64},Matrix{Float64}}, y::Union{Vector{Float64},Matrix{Float64}}) = dr(y)
+(dr::DecisionRule{EmptyGrid, CartesianGrid})(z::AbstractMatrix{Float64}) = evaluate(dr,z)
+(dr::DecisionRule{EmptyGrid, CartesianGrid})(z::AbstractVector{Float64}) = dr(z')[:]
+(dr::DecisionRule{EmptyGrid, CartesianGrid})(i::Int, x::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = dr(x)
+(dr::DecisionRule{EmptyGrid, CartesianGrid})(x::Union{AbstractVector{Float64},AbstractMatrix{Float64}}, y::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = dr(y)
 
 
 ####
@@ -134,7 +134,7 @@ function set_values!(dr::Dolo.AbstractDecisionRule{Dolo.CartesianGrid, Dolo.Cart
     dr.coefficients = [Dolo.filter_mcoeffs(a,b,orders,vv)]
 end
 
-function evaluate(dr::AbstractDecisionRule{CartesianGrid, CartesianGrid}, z::Matrix{Float64})
+function evaluate(dr::AbstractDecisionRule{CartesianGrid, CartesianGrid}, z::AbstractMatrix{Float64})
     a = cat(1, dr.grid_exo.min, dr.grid_endo.min)
     b = cat(1, dr.grid_exo.max, dr.grid_endo.max)
     n = cat(1, dr.grid_exo.n, dr.grid_endo.n)
@@ -143,12 +143,12 @@ function evaluate(dr::AbstractDecisionRule{CartesianGrid, CartesianGrid}, z::Mat
     return res
 end
 
-(dr::DecisionRule{CartesianGrid, CartesianGrid})(z::Matrix{Float64}) = evaluate(dr,z)
-(dr::DecisionRule{CartesianGrid, CartesianGrid})(z::Vector{Float64}) = dr(z')[:]
-(dr::DecisionRule{CartesianGrid, CartesianGrid})(x::Vector{Float64},y::Vector{Float64}) = dr(cat(1,x,y))
-(dr::DecisionRule{CartesianGrid, CartesianGrid})(x::Matrix{Float64},y::Matrix{Float64}) = dr([x y])
-(dr::DecisionRule{CartesianGrid, CartesianGrid})(x::Vector{Float64},y::Matrix{Float64}) = dr([repmat(x',size(y,1),1) y])
-(dr::DecisionRule{CartesianGrid, CartesianGrid})(i::Int,y::Union{Vector{Float64},Matrix{Float64}}) = dr(node(dr.grid_exo,i),y)
+(dr::DecisionRule{CartesianGrid, CartesianGrid})(z::AbstractMatrix{Float64}) = evaluate(dr,z)
+(dr::DecisionRule{CartesianGrid, CartesianGrid})(z::AbstractVector{Float64}) = dr(z')[:]
+(dr::DecisionRule{CartesianGrid, CartesianGrid})(x::AbstractVector{Float64},y::AbstractVector{Float64}) = dr(cat(1,x,y))
+(dr::DecisionRule{CartesianGrid, CartesianGrid})(x::AbstractMatrix{Float64},y::AbstractMatrix{Float64}) = dr([x y])
+(dr::DecisionRule{CartesianGrid, CartesianGrid})(x::AbstractVector{Float64},y::AbstractMatrix{Float64}) = dr([repmat(x',size(y,1),1) y])
+(dr::DecisionRule{CartesianGrid, CartesianGrid})(i::Int,y::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = dr(node(dr.grid_exo,i),y)
 
 
 ####
@@ -187,8 +187,8 @@ function evaluate(dr::AbstractDecisionRule{UnstructuredGrid, CartesianGrid}, i::
     return res
 end
 
-(dr::DecisionRule{UnstructuredGrid, CartesianGrid})(i::Int,y::Matrix{Float64}) = evaluate(dr,i,y)
-(dr::DecisionRule{UnstructuredGrid, CartesianGrid})(i::Int,y::Vector{Float64}) = dr(i,y')[:]
+(dr::DecisionRule{UnstructuredGrid, CartesianGrid})(i::Int,y::AbstractMatrix{Float64}) = evaluate(dr,i,y)
+(dr::DecisionRule{UnstructuredGrid, CartesianGrid})(i::Int,y::AbstractVector{Float64}) = dr(i,y')[:]
 
 
 
@@ -214,10 +214,10 @@ set_values!(cdr::CachedDecisionRule, v) = set_values!(cdr.dr,v)
 
 # defaults
 
-(cdr::CachedDecisionRule)(v::Union{Vector{Float64},Matrix{Float64}}) = cdr.dr(v)
-(cdr::CachedDecisionRule)(m::Union{Vector{Float64},Matrix{Float64}},s::Union{Vector{Float64},Matrix{Float64}}) = cdr.dr(m,s)
-(cdr::CachedDecisionRule)(i::Int,s::Union{Vector{Float64},Matrix{Float64}}) = cdr.dr(node(cdr.process,i),s)
-(cdr::CachedDecisionRule)(i::Int,j::Int,s::Union{Vector{Float64},Matrix{Float64}}) = cdr.dr(inode(cdr.process,i,j),s)
+(cdr::CachedDecisionRule)(v::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = cdr.dr(v)
+(cdr::CachedDecisionRule)(m::Union{AbstractVector{Float64},AbstractMatrix{Float64}},s::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = cdr.dr(m,s)
+(cdr::CachedDecisionRule)(i::Int,s::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = cdr.dr(node(cdr.process,i),s)
+(cdr::CachedDecisionRule)(i::Int,j::Int,s::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = cdr.dr(inode(cdr.process,i,j),s)
 
-(cdr::CachedDecisionRule{DecisionRule{UnstructuredGrid, CartesianGrid}, DiscreteMarkovProcess})(i::Int,s::Union{Vector{Float64},Matrix{Float64}}) = cdr.dr(i,s)
-(cdr::CachedDecisionRule{DecisionRule{UnstructuredGrid, CartesianGrid}, DiscreteMarkovProcess})(i::Int,j::Int,s::Union{Vector{Float64},Matrix{Float64}}) = cdr.dr(j,s)
+(cdr::CachedDecisionRule{DecisionRule{UnstructuredGrid, CartesianGrid}, DiscreteMarkovProcess})(i::Int,s::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = cdr.dr(i,s)
+(cdr::CachedDecisionRule{DecisionRule{UnstructuredGrid, CartesianGrid}, DiscreteMarkovProcess})(i::Int,j::Int,s::Union{AbstractVector{Float64},AbstractMatrix{Float64}}) = cdr.dr(j,s)

--- a/test/test_algos.jl
+++ b/test/test_algos.jl
@@ -12,6 +12,8 @@ drc = Dolo.ConstantDecisionRule(model_mc.calibration[:controls])
 @time dr = Dolo.time_iteration(model_mc, verbose=true, maxit=10000)
 @time drv = Dolo.evaluate_policy(model_mc, dr) #, verbose=true, maxit=10000)
 @time drd = Dolo.time_iteration_direct(model_mc, dr) #, maxit=500)
+
+
 #
 # # compare with prerecorded values
 # kvec = linspace(dr.grid.min[1],dr.grid.max[1],10)
@@ -60,11 +62,11 @@ res
 Dolo.simulate(model, dr)
 
 s0 = model.calibration[:states]+0.1
-sim = Dolo.simulate(model, dr, s0; stochastic=true)
-Dolo.simulate(model, dr, n_exp=10)
+sim = Dolo.simulate(model, dr, s0)
+Dolo.simulate(model, dr, N=10)
 
 # this doesn't work here
-irf = Dolo.response(model, dr, [0.1])
+irf = Dolo.response(model, dr, :e_z)
 irf[:k]
 
 
@@ -85,6 +87,7 @@ import Dolo
 fn = Pkg.dir("Dolo","examples","models","rbc_dtcc_ar1.yaml")
 model = Dolo.yaml_import(fn)
 dp = Dolo.discretize(model.exogenous)
+
 @time dr = Dolo.perturbate(model)
 cdr =Dolo.CachedDecisionRule(dr,dp)
 @time dr = Dolo.time_iteration(model, model.exogenous, cdr)
@@ -93,7 +96,7 @@ cdr =Dolo.CachedDecisionRule(dr,dp)
 @time drv = Dolo.evaluate_policy(model, dr, verbose=true, maxit=10000)
 @time drd = Dolo.time_iteration_direct(model, dr) #, verbose=true) #, maxit=500)
 #
+model.symbols[:exogenous]
 
-Dolo.simulate(model, dr, n_exp=10)
-sim = Dolo.response(model, dr, [0.01])
-sim
+Dolo.simulate(model, dr, N=10)
+sim = Dolo.response(model, dr, :z)


### PR DESCRIPTION
This complements the discussion in #34 . 

Problem was the evaluation of d.r. rules was defined like `dr(x::Array{Float64})` which makes it incompatible with array views. I haven't changed the other defintions though (meaning that coefficients of a d.r. still must be contiguous arrays).

I did another small fix: renamed the constant field of VAR1 objects from  `M` to `mu` which makes it consistent with the notation in `MvNormal` (and fixes the `response` function).