### PR TITLE
WIP: options

### DIFF
--- a/examples/example_options.jl
+++ b/examples/example_options.jl
@@ -1,0 +1,13 @@
+import Dolo
+
+model = Dolo.Model(Pkg.dir("Dolo","examples","models","rbc_dtcc_mc.yaml"))
+
+Dolo.time_iteration(model)
+dr0 = Dolo.time_iteration(model, details=false, tol_η=1e-6; grid=Dict(:n=>[5]))
+sol = Dolo.time_iteration(model, maxit=1000; grid=Dict(:n=>[100]))
+
+# faster version: limit the number of steps in the newton solver
+@time sol = Dolo.time_iteration(model, maxit=1000; solver=Dict(:maxit=>2), grid=Dict(:n=>[100]))
+
+# or use explicit formulas given in the model
+@time sol = Dolo.time_iteration(model, maxit=1000; solver=Dict(:type=>:direct), grid=Dict(:n=>[100]))

--- a/examples/models/rbc_dtcc_iid.yaml
+++ b/examples/models/rbc_dtcc_iid.yaml
@@ -53,13 +53,14 @@ calibration:
     sigma: 5
     eta: 1
     sig_z: 0.016
-    zbar: 0
+    zbar: 0.0
     chi : w/c^sigma/n^eta
     c_i: 1.5
     c_y: 0.5
     e_z: 0.0
 
     # endogenous variables
+    z: 0.0
     n: 0.33
     z: zbar
     rk: 1/beta-1+delta

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -103,11 +103,11 @@ If the stochastic process for the model is not explicitly provided, the process 
 * `dr`: Solved decision rule.
 """
 function time_iteration(model, dprocess::AbstractDiscretizedProcess, init_dr;
-      verbose::Bool=true, maxit::Int=100, tol::Float64=1e-8, details::Bool=true)
+          verbose::Bool=true, maxit::Int=100, tol::Float64=1e-8, options=Dict(), details::Bool=true)
 
     # get grid for endogenous
-    grid = model.grid
-    # grid = CartesianGrid(gg.a, gg.b, gg.orders)  # temporary compatibility
+    grid = get_grid(model, options=options)
+
 
     endo_nodes = nodes(grid)
     N = size(endo_nodes, 1)

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -102,11 +102,16 @@ If the stochastic process for the model is not explicitly provided, the process 
 # Returns
 * `dr`: Solved decision rule.
 """
-function time_iteration(model, dprocess::AbstractDiscretizedProcess, init_dr;
-          verbose::Bool=true, maxit::Int=100, tol::Float64=1e-8, options=Dict(), details::Bool=true)
+function time_iteration(model::Model, dprocess::AbstractDiscretizedProcess,
+                        grid, init_dr;
+          verbose::Bool=true, details::Bool=true,
+          maxit::Int=100, tol_η::Float64=1e-8,
+          solver=Dict())
 
-    # get grid for endogenous
-    grid = get_grid(model, options=options)
+    if get(solver,:type,nothing) == :direct
+        return time_iteration_direct(model, dprocess, grid, init_dr;
+                  verbose=verbose, details=details, maxit=maxit, tol_η=tol_η)
+    end
 
 
     endo_nodes = nodes(grid)
@@ -142,7 +147,6 @@ function time_iteration(model, dprocess::AbstractDiscretizedProcess, init_dr;
 
     # loop option
     init_res = residual(model, dprocess, endo_nodes, x0, p, dr)
-    it = 0
     err = maximum(abs, stack0(init_res))
     err_0 = err
 
@@ -150,7 +154,8 @@ function time_iteration(model, dprocess::AbstractDiscretizedProcess, init_dr;
     verbose && println(repeat("-", 35))
     verbose && @printf "%-6i%-12.2e%-12.2e%-5i\n" 0 err NaN 0
 
-    while it<maxit && err>tol
+    it = 0
+    while it<maxit && err>tol_η
 
         it += 1
 
@@ -158,7 +163,7 @@ function time_iteration(model, dprocess::AbstractDiscretizedProcess, init_dr;
 
         xx0 = stack0(x0)
         fobj(u) = residual(model, dprocess, endo_nodes, u, p, dr)
-        xx1, nit = serial_solver(fobj, xx0, lb, ub, maxit=10, verbose=false)
+        xx1, nit = serial_solver(fobj, xx0, lb, ub; solver...)
         x1 = destack0(xx1, nsd)
 
         err = maximum(abs, xx1 - xx0)
@@ -174,28 +179,34 @@ function time_iteration(model, dprocess::AbstractDiscretizedProcess, init_dr;
     if !details
         return dr.dr
     else
-        converged = err<tol
-        TimeIterationResult(dr.dr, it, true, converged, tol, err)
+        converged = err<tol_η
+        TimeIterationResult(dr.dr, it, true, converged, tol_η, err)
     end
 
 end
 
+# get grid for endogenous
+function time_iteration(model, dprocess, dr; grid=Dict(), kwargs...)
+    grid = get_grid(model, options=grid)
+    return time_iteration(model, dprocess, grid, dr;  kwargs...)
+end
 
 # get stupid initial rule
-function time_iteration(model, dprocess::AbstractDiscretizedProcess; kwargs...)
+function time_iteration(model, dprocess::AbstractDiscretizedProcess; grid=Dict(), kwargs...)
+
     init_dr = ConstantDecisionRule(model.calibration[:controls])
-    return time_iteration(model, dprocess, init_dr;  kwargs...)
+    return time_iteration(model, dprocess, init_dr;  grid=grid, kwargs...)
 end
 
 
-function time_iteration(model, init_dr; kwargs...)
+function time_iteration(model, init_dr; grid=Dict(), kwargs...)
     dprocess = discretize( model.exogenous )
-    return time_iteration(model, dprocess, init_dr; kwargs...)
+    return time_iteration(model, dprocess, init_dr; grid=grid, kwargs...)
 end
 
 
-function time_iteration(model; kwargs...)
+function time_iteration(model; grid=Dict(), kwargs...)
     dprocess = discretize( model.exogenous )
     init_dr = ConstantDecisionRule(model.calibration[:controls])
-    return time_iteration(model, dprocess, init_dr; kwargs...)
+    return time_iteration(model, dprocess, init_dr; grid=grid, kwargs...)
 end

--- a/src/algos/time_iteration_direct.jl
+++ b/src/algos/time_iteration_direct.jl
@@ -12,11 +12,10 @@ If the stochastic process for the model is not explicitly provided, the process 
 # Returns
 * `dr`: Solved decision rule.
 """
-function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess, init_dr;
-    verbose::Bool=true, maxit::Int=100, tol::Float64=1e-8, details::Bool=true)
+function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess, grid, init_dr;
+    verbose::Bool=true, maxit::Int=100, tol_η::Float64=1e-8, details::Bool=true)
 
     # Grid
-    grid = model.grid
     endo_nodes = nodes(grid)
     N = size(endo_nodes, 1)
 
@@ -53,7 +52,7 @@ function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess, init
 
     ###############################   Iteration loop
 
-    while it<maxit && err>tol
+    while it<maxit && err>tol_η
 
       it+=1
       # dr = CachedDecisionRule(process, grid, x0)
@@ -100,27 +99,27 @@ function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess, init
     if !details
         return dr.dr
     else
-        converged = err<tol
-        TimeIterationResult(dr.dr, it, converged, true, tol, err)
+        converged = err<tol_η
+        TimeIterationResult(dr.dr, it, converged, true, tol_η, err)
     end
 
 end
-
-# get stupid initial rule
-function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess; kwargs...)
-    init_dr = ConstantDecisionRule(model.calibration[:controls])
-    return time_iteration_direct(model, dprocess, init_dr;  kwargs...)
-end
-
-
-function time_iteration_direct(model, init_dr; kwargs...)
-    dprocess = discretize( model.exogenous )
-    return time_iteration_direct(model, dprocess, init_dr; kwargs...)
-end
-
-
-function time_iteration_direct(model; kwargs...)
-    dprocess = discretize( model.exogenous )
-    init_dr = ConstantDecisionRule(model.calibration[:controls])
-    return time_iteration_direct(model, dprocess, init_dr; kwargs...)
-end
+#
+# # get stupid initial rule
+# function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess; kwargs...)
+#     init_dr = ConstantDecisionRule(model.calibration[:controls])
+#     return time_iteration_direct(model, dprocess, init_dr;  kwargs...)
+# end
+#
+#
+# function time_iteration_direct(model, init_dr; kwargs...)
+#     dprocess = discretize( model.exogenous )
+#     return time_iteration_direct(model, dprocess, init_dr; kwargs...)
+# end
+#
+#
+# function time_iteration_direct(model; kwargs...)
+#     dprocess = discretize( model.exogenous )
+#     init_dr = ConstantDecisionRule(model.calibration[:controls])
+#     return time_iteration_direct(model, dprocess, init_dr; kwargs...)
+# end

--- a/src/model.jl
+++ b/src/model.jl
@@ -99,8 +99,9 @@ function get_infos(model::ASModel)
     get(model.data, :infos, Dict())
 end
 
-function get_options(model::ASModel)
-    get(model.data, :options, Dict())
+function get_options(model::ASModel; options=Dict())
+    opts = get(model.data, :options, Dict())
+    return rmerge(opts, options)
 end
 
 function get_definitions(model::ASModel)
@@ -135,24 +136,20 @@ function get_domain(model::ASModel)
     return Domain(states, min, max)
 end
 
-function get_grid(model::ASModel)
+function get_grid(model::ASModel; options=Dict())
     domain = get_domain(model)
     d = length(domain.states)
-    grid_dict = model.data[:options][:grid]
+    options = get_options(model; options=options)
+    grid_dict = options[:grid]
     if grid_dict[:tag] == :Cartesian
-        # TODO simplify...
-
-        ogrid = model.data[:options][:grid]
-        orders = get(ogrid, :orders, [20 for i=1:d])
+        orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = Dolo.CartesianGrid(domain.min, domain.max, orders)
     elseif grid_dict[:tag] == :Smolyak
-        ogrid = model.data[:options][:grid]
-        mu = ogrid[:mu]
+        mu = grid_dict[:mu]
         grid = Dolo.SmolyakGrid(domain.min, domain.max, mu)
     else
         error("Unknown grid type.")
     end
-
     return grid
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -139,8 +139,11 @@ end
 function get_grid(model::ASModel; options=Dict())
     domain = get_domain(model)
     d = length(domain.states)
-    options = get_options(model; options=options)
+    options = get_options(model; options=Dict(:grid=>options))
     grid_dict = options[:grid]
+    if :type in keys(grid_dict)
+        grid_dict[:tag] = grid_dict[:type]
+    end
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = Dolo.CartesianGrid(domain.min, domain.max, orders)

--- a/src/numeric/newton.jl
+++ b/src/numeric/newton.jl
@@ -155,7 +155,7 @@ end
 #
 # end
 
-function serial_solver(f::Function, x0::Array{Float64,2}, a, b; maxit=10, verbose=true)
+function serial_solver(f::Function, x0::Array{Float64,2}, a, b; maxit=10, verbose=false, n_bsteps=5, lam_bsteps=0.5)
 
     fun(u) = -f(u)
     smooth_me = true
@@ -177,7 +177,7 @@ function serial_solver(f::Function, x0::Array{Float64,2}, a, b; maxit=10, verbos
     it = 0;
 
     n_bsteps = 5
-    backsteps = 0.5.^(0:(n_bsteps-1))
+    backsteps = lam_bsteps.^(0:(n_bsteps-1))
 
     x = x0
     res = fun(x0)

--- a/src/util.jl
+++ b/src/util.jl
@@ -109,3 +109,22 @@ function fkron(A::AbstractMatrix{Float64}, B::AbstractMatrix{Float64})
     end
     return C
 end
+
+
+
+rmerge(default_struct, add_options) = add_options
+function rmerge(def_s::Associative, add_s::Associative)
+    kl = collect(keys(def_s))
+    kr = collect(keys(add_s))
+    resp = Dict()
+    for k in intersect(kl,kr)
+        resp[k] = rmerge(def_s[k],add_s[k])
+    end
+    for k in setdiff(kl, kr)
+        resp[k] = def_s[k]
+    end
+    for k in setdiff(kr, kl)
+        resp[k] = add_s[k]
+    end
+    return resp
+end


### PR DESCRIPTION
I would like to have a consistent way to pass options to all functions in a way that is consistent with yaml file.
Let assume the yaml file ends up with:
```
domain:
   k: [0,1]
exogenous: !VAR1
   rho: sig_z
options:
   grid: !Cartesian
      n: [10,10]
   interpolation: cubic
   discretize: # doesn't exist
      method: rouwenhorst
      mu: 3
```
I suggest to define:
```
time_iteration(model; options=Dict())
```
`options` would expect dict-of-dict input and would be merged recursively with the data from the yaml file. For instance, one could pass `options=Dict(:grid=>Dict(:type=>:Smolyak))` and that would be equivalent to:
```
options:
   grid: !Smolak
      n: [10,10]
   interpolation: cubic
   discretize: # doesn't exist
      method: rouwenhorst
      mu: 3
```
This raises several potential issues:
- Dict-of-Dict are not nice in Julia since `{}` syntax disappeared. Potential solution, accept structures [:a=>b, :k=>[:a=>[0,0]]]` and convert them on the fly.
- another possibility would be to have special keywords replace a predefined subtree of options. So `time_it(.., grid=some_dict)` would merge `some_dict` with the subdict `options:grid`.
- fields outside of `options` like `exogenous` or `domain` would need additional kwargs, which is a bit annoying. So the current behaviour implies that to set them one needs to modify model data and make a `set_calibration` call. If the second option is kept, it would be aanother special case of it.
- in the current python implementation types are given by a key `type` but it's `tag` in the julia version. `type` seems more natural to me in both cases as tag really is inherited from yaml vocabulary
- another question is how to deal with excess parameters: with the merging mechanism, one can end up with a structure `Cartesian(min=, max=, orders=, mu=3)`. At which point should the `mu` be dropped ? Should a warning be issued ?

