### PR TITLE
Albop/prettify

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -19,7 +19,7 @@ function sanitize(eq::Expr, dynvars::Array{Symbol,1})
     end
 end
 
-function sanitize(a,model::Dolo.SModel)
+function sanitize(a,model::Dolo.ASModel)
     dynvars = get_variables(model)
     return sanitize(a, dynvars)
 end


### PR DESCRIPTION
This PR does 3 things:
- improve the output of time_iterations / value_iterations
- fix model printing in the notebook
- remove details options for VFI/TI

Note that value_iteration seems broken as the call to Optim doesn't work anymore.