### PR TITLE
RFC: simulate definitions routine

### DIFF
--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -27,7 +27,7 @@ import Distributions
 using AxisArrays
 
 # Compat across julia versions
-using Compat; import Compat: String, view
+using Compat; import Compat: String, view, @__dot__
 
 
 # exports

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -37,7 +37,8 @@ export arbitrage, transition, auxiliary, value, expectation,
 
        # mutating version of model functions
        arbitrage!, transition!, auxiliary!, value!, expectation!,
-       direct_response, controls_lb!, controls_ub!, arbitrage_2!, felicity!
+       direct_response, controls_lb!, controls_ub!, arbitrage_2!, felicity!,
+       evaluate_definitions
 
        # dolo functions
 export yaml_import, eval_with, evaluate, evaluate!, model_type, name, filename, id
@@ -82,10 +83,10 @@ include("numeric/processes.jl")
 include("numeric/decision_rules.jl")
 
 include("util.jl")
-include("symbolic.jl")
 include("calibration.jl")
 include("minilang.jl")
 include("model.jl")
+include("symbolic.jl")
 include("printing.jl")
 
 include("algos/steady_state.jl")

--- a/src/algos/perturbation.jl
+++ b/src/algos/perturbation.jl
@@ -18,8 +18,7 @@ end
 
 function Base.show(io::IO, pbr::PerturbationResult)
     @printf io "Perturbation Results\n"
-    @printf io " * Decision Rule type: %s\n" string(typeof(PerturbationResult))
-    @printf io "   * %s\n" show(pbr.solution)
+    @printf io " * Decision Rule type: %s\n" string(typeof(pbr))
     @printf io " * Blanchard-Kahn: %s\n" blanchard_kahn(pbr)
     @printf io "   * stable < %s\n" pbr.stable
     @printf io "   * determined < %s\n" pbr.determined

--- a/src/model.jl
+++ b/src/model.jl
@@ -211,6 +211,8 @@ type Model{ID} <: AModel{ID}
             eval(Dolo, code)
         end
 
+        eval(Dolo, build_definition_function(model))
+
         return model
     end
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -112,3 +112,110 @@ function _handle_arbitrage(arb, controls)
     end
     controls_lb, controls_ub, arbitrage
 end
+
+"""
+    build_definition_function(model::Model, defs::Associative=model.definitions)
+
+Generate the code for a Julia function that will evalaute all the definitions
+for the model, given an AxisArray containing all states, controls, and
+exogenous values.
+
+The signature of the resulting method will be
+
+    evaluate_definitions(::Model, data::AxisArray, p)
+
+where `p` is the vector of model parameters.
+
+The return value is an AxisArray containing the definitions. Will be padded
+with NaNs if needed because of non-zero timing in definitions
+
+"""
+function build_definition_function{T<:Model}(
+        model::T,
+        defs::Associative=model.definitions;
+        funname::Symbol=:evaluate_definitions
+    )
+    defs = OrderedDict(defs)
+    # used to unpack parameters
+    a_factory = first(model.factories)[2]
+
+    # get incidence table for each definition -- skip tracking parameters
+    it = Dolang.IncidenceTable(collect(values(defs)), model.symbols[:parameters])
+
+    # need to construct a block for unpacking variables from AxisArrays
+    unpack_data_block = Expr(:block)
+    for (var, dates) in it.by_var
+        _var = Base.QuoteNode(var)
+        if haskey(defs, var)
+            continue
+        end
+        for date in dates
+            lhs = Dolang.normalize((var, date))
+
+            # if date is non-zero, need to pad array with nans
+            if date < 0
+                # negative dates requires padding the front of the array
+                rhs = :(vcat(fill(NaN, $(abs(date))), data[:, $_var, 1:(capT- $date)]))
+            elseif date > 0
+                # positive date pad the end
+                rhs = :(vcat(data[:, $_var, (1+$date):capT], fill(NaN, $(date))))
+            else
+                rhs = :(data[:, $_var, :])
+            end
+            push!(unpack_data_block.args, :($lhs = $rhs))
+        end
+    end
+
+    # compute incidence one more time, but don't track stuff we already know
+    known_vars = vcat(model.symbols[:parameters], get_variables(model))
+    it_defs = Dolang.IncidenceTable(
+        collect(values(defs)),
+        known_vars
+    )
+
+    # figure out the order for computing definitions
+    def_order = Dolang.solution_order(defs, it_defs, known_vars)
+    dot_call(ex) = Expr(:macrocall, Symbol("@__dot__"), Dolang.normalize(ex))
+    def_exprs =[Expr(:(=), Dolang.normalize((lhs, 0)), dot_call(rhs))
+        for (lhs, rhs) in defs
+    ][def_order]
+    def_block = Expr(:block, def_exprs...)
+
+    # finally package up the definitions
+    # need to reshape all the defs we just computed so we can cat them in dim 2
+    cat_expr = Expr(
+        :call, :cat, 2,
+        [Expr(:call, :reshape, Dolang.normalize((v, 0)), Expr(:tuple, :capN, 1, :capT))
+         for v in keys(defs)]...
+    )
+    # need an axis for the variable dimension
+    def_axis = :(Axis{:V}($(collect(keys(defs)))))
+
+    # shove the output into an AxisArray
+    out_block = Expr(:block,
+        :(out_raw = $cat_expr),
+        :(return AxisArray(out_raw, data.axes[1], $(def_axis), (data.axes[3])))
+    )
+
+    quote
+        function $(funname){T1}(::$T, data::AxisArray{T1,3}, p)
+            capT = size(data, 3)
+            capN = size(data, 1)
+            $(Dolang.param_block(a_factory))
+            $unpack_data_block
+            $def_block
+            $out_block
+
+        end
+        function $(funname){T1}(model::$T, tab::AxisArray{T1,2}, p)
+            # add leading dimension for N
+            data = AxisArray(reshape(tab.data, (1, size(tab)...)), Axis{:N}(1:1), tab.axes...)
+
+            # call method above that does panel
+            def_data = $(funname)(model, data, p)
+
+            # drop first dimension from the panel
+            return def_data[1, :, :]
+        end
+    end
+end


### PR DESCRIPTION
This takes a stab at #70 

We should be able to call `evaluate_definitions(model, data, model.calibration[:parameters])` where `data` is the current output of either `simulate` or `tabulate`.

```

import Dolo
model = Dolo.yaml_import(joinpath(Dolo.pkg_path, "examples", "models", "sudden_stop_ar1.yaml"))
ti_res = Dolo.time_iteration(model);
data = Dolo.simulate(model, ti_res.dr, N=5, T=10)
defs = Dolo.evaluate_definitions(model, data, model.calibration[:parameters])
```

The underlying code comes with some flexibility in being able to specify arbitrary expressions to be evaluated on the simulated data (e.g. we aren't limited to `model.definitions`).

We could put this in the `simulate` and `tabulate` methods, but I didn't do it yet. What do you think @albop  and @AnasZa ?

Closes #70 