### PR TITLE
WIP: playing with product processes.

### DIFF
--- a/examples/models/rbc_catastrophe.yaml
+++ b/examples/models/rbc_catastrophe.yaml
@@ -4,7 +4,7 @@ model_type: dtcc
 
 symbols:
 
-   exogenous: [z, u]
+   exogenous: [z, xi]
    states: [k]
    controls: [n, i]
    expectations: [m]
@@ -13,7 +13,7 @@ symbols:
    rewards: [u]
 
 definitions:
-    y: exp(z-u)*k^alpha*n^(1-alpha)
+    y: exp(z-xi)*k^alpha*n^(1-alpha)
     c: y - i
     rk: alpha*y/k
     w: (1-alpha)*y/n
@@ -38,8 +38,8 @@ equations:
         - m = beta/c(1)^sigma*(1-delta+rk(1))
 
     direct_response:
-        - n = ((1-alpha)*exp(z-u)*k^alpha*m/chi)^(1/(eta+alpha))
-        - i = exp(z-u)*k^alpha*n^(1-alpha) - (m)^(-1/sigma)
+        - n = ((1-alpha)*exp(z-xi)*k^alpha*m/chi)^(1/(eta+alpha))
+        - i = exp(z-xi)*k^alpha*n^(1-alpha) - (m)^(-1/sigma)
 
 calibration:
 
@@ -71,7 +71,7 @@ calibration:
     c: y - i
     V: log(c)/(1-beta)
     u: c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)
-
+    xi: 0.0
 
 domain:
     k: [k*0.5, k*1.5]

--- a/examples/models/rbc_catastrophe.yaml
+++ b/examples/models/rbc_catastrophe.yaml
@@ -1,0 +1,90 @@
+name: Real Business Cycle
+
+model_type: dtcc
+
+symbols:
+
+   exogenous: [z, u]
+   states: [k]
+   controls: [n, i]
+   expectations: [m]
+   values: [V]
+   parameters: [beta, sigma, eta, chi, delta, alpha, rho, zbar, sig_z]
+   rewards: [u]
+
+definitions:
+    y: exp(z-u)*k^alpha*n^(1-alpha)
+    c: y - i
+    rk: alpha*y/k
+    w: (1-alpha)*y/n
+
+equations:
+
+    arbitrage:
+        - chi*n^eta*c^sigma - w                      | 0 <= n <= inf
+        - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))  | 0 <= i <= inf
+        # - V0 = c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta) + beta*V0(1) |  -100000<=V0<=100000
+
+    transition:
+        - k = (1-delta)*k(-1) + i(-1)
+
+    value:
+        - V = c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta) + beta*V(1)
+
+    felicity:
+        - u =  c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)
+
+    expectation:
+        - m = beta/c(1)^sigma*(1-delta+rk(1))
+
+    direct_response:
+        - n = ((1-alpha)*exp(z-u)*k^alpha*m/chi)^(1/(eta+alpha))
+        - i = exp(z-u)*k^alpha*n^(1-alpha) - (m)^(-1/sigma)
+
+calibration:
+
+    # parameters
+    beta: 0.99
+    phi: 1
+    delta : 0.025
+    alpha : 0.33
+    rho : 0.8
+    sigma: 5
+    eta: 1
+    sig_z: 0.016
+    zbar: 0
+    chi : w/c^sigma/n^eta
+    c_i: 1.5
+    c_y: 0.5
+    e_z: 0.0
+    m: 0
+    V0: (c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta))/(1-beta)
+
+    # endogenous variables
+    n: 0.33
+    z: zbar
+    rk: 1/beta-1+delta
+    w: (1-alpha)*exp(z)*(k/n)^(alpha)
+    k: n/(rk/alpha)^(1/(1-alpha))
+    y: exp(z)*k^alpha*n^(1-alpha)
+    i: delta*k
+    c: y - i
+    V: log(c)/(1-beta)
+    u: c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)
+
+
+domain:
+    k: [k*0.5, k*1.5]
+
+exogenous: !Product
+    p1: !VAR1
+         rho: 0.8
+         Sigma: [[0.001]]
+    p2: !MarkovChain
+        values: [[0.0],[0.1]]
+        transitions: [[0.97, 0.03], [0.1, 0.9]]
+
+options:
+
+    grid: !Cartesian
+        orders: [50]

--- a/src/minilang.jl
+++ b/src/minilang.jl
@@ -92,6 +92,20 @@ function _build_exogenous_entry(data::Associative, calib::ModelCalibration)
         Sigma = eval_with(calib, data[:Sigma])
         Sigma = to_matrix(Sigma)
         return Normal(Sigma)
+    elseif data[:tag] == :DeathProcess
+        # need to extract rho an dSigma
+        mu = eval_with(calib, data[:mu])
+        return DeathProcess(mu)
+    elseif data[:tag] == :PoissonProcess
+        # need to extract rho an dSigma
+        mu = eval_with(calib, data[:mu])
+        K = eval_with(calib, data[:K])
+        return PoissonProcess(mu, K)
+    elseif data[:tag] == :AgingProcess
+        # need to extract rho an dSigma
+        mu = eval_with(calib, data[:mu])
+        K = eval_with(calib, data[:K])
+        return AgingProcess(mu, K)
     end
     m = "don't know how to handle exogenous process of type $(data[:tag])"
     error(m)

--- a/src/minilang.jl
+++ b/src/minilang.jl
@@ -67,7 +67,11 @@ to_matrix(tab::Array{Array{Float64,1},1}) = cat(1, [e' for e in tab]...)
 
 function _build_exogenous_entry(data::Associative, calib::ModelCalibration)
 
-    if data[:tag] == :MarkovChain
+    if data[:tag] == :Product
+        p1 = _build_exogenous_entry(data[:p1], calib)
+        p2 = _build_exogenous_entry(data[:p2], calib)
+        return ProductProcess(p1,p2)
+    elseif data[:tag] == :MarkovChain
         # need to extract/clean up P and Q
         values = eval_with(calib, data[:values])
         states_values = to_matrix(values)

--- a/src/model.jl
+++ b/src/model.jl
@@ -12,6 +12,9 @@ const yaml_types = let
              ("!Normal", :Normal),
              ("!MarkovChain", :MarkovChain),
              ("!Product", :Product),
+             ("!PoissonProcess", :PoissonProcess),
+             ("!DeathProcess", :DeathProcess),
+             ("!AgingProcess", :AgingProcess),
              ("!VAR1", :VAR1)]
     Dict{AbstractString,Function}([(t, (c, n) -> construct_type_map(s, c, n))
                            for (t, s) in pairs])

--- a/src/model.jl
+++ b/src/model.jl
@@ -11,6 +11,7 @@ const yaml_types = let
             ("!Smolyak", :Smolyak),
              ("!Normal", :Normal),
              ("!MarkovChain", :MarkovChain),
+             ("!Product", :Product),
              ("!VAR1", :VAR1)]
     Dict{AbstractString,Function}([(t, (c, n) -> construct_type_map(s, c, n))
                            for (t, s) in pairs])

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -357,6 +357,38 @@ function discretize(pp::ProductProcess; kwargs...)
 end
 
 
+## special processes (could be implemented as types later on)
+
+function DeathProcess(mu::Float64)
+    values = [0.0 1.0;]'
+    transitions = [(1-mu) mu; 0 1]
+    DiscreteMarkovProcess(transitions, values)
+end
+function PoissonProcess(mu::Float64, K::Int)
+    values = (0:K)[:,:]*1.0
+    transitions = zeros(K+1, K+1)
+    for i=1:K
+        transitions[i,i] = 1-mu
+        transitions[i,i+1] = mu
+    end
+    transitions[K+1,K+1] = 1
+    DiscreteMarkovProcess(transitions, values)
+end
+function AgingProcess(mu::Float64, K::Int)
+    values = zeros(K+1,2)
+    values[:,1] = 0:K
+    values[1,2] = 1
+    transitions = zeros(K+1, K+1)
+    transitions[1,1] = 1
+    for i=2:K
+        transitions[i,i+1] = (1-mu)
+        transitions[i,1] = mu
+    end
+    transitions[end,1] = 1
+    return DiscreteMarkovProcess(transitions, values)
+end
+
+
 # compatibility names
 @compat const AR1 = VAR1
 @compat const MarkovChain = DiscreteMarkovProcess

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -11,6 +11,7 @@
 ### Discretized process
 ###
 
+
 # date-t grid has a known structure
 type DiscretizedProcess{TG<:Grid} <: AbstractDiscretizedProcess
     grid::TG
@@ -30,6 +31,9 @@ type DiscreteMarkovProcess <: AbstractDiscretizedProcess
     transitions::Matrix{Float64}
     values::Matrix{Float64}
 end
+
+discretize(::Type{DiscreteMarkovProcess}, mp::DiscreteMarkovProcess) = mp
+discretize(mp::DiscreteMarkovProcess) = mp
 
 DiscreteMarkovProcess(transitions::Matrix{Float64}, values::Matrix{Float64}) =
     DiscreteMarkovProcess(UnstructuredGrid(values), transitions, values)
@@ -334,6 +338,23 @@ function ErgodDist(var::VAR1, N::Int, T::Int)
     return Mean_sim, Sigma_sim, R_sim
 end
 
+#### ProductProcess
+
+
+type ProductProcess <: AbstractProcess
+    process_1::AbstractProcess
+    process_2::AbstractProcess
+end
+
+function discretize(::Type{DiscreteMarkovProcess}, pp::ProductProcess; opt1=Dict(), opt2=Dict())
+    p1 = discretize(DiscreteMarkovProcess, pp.process_1; opt1...)
+    p2 = discretize(DiscreteMarkovProcess, pp.process_2; opt2...)
+    return MarkovProduct(p1,p2)
+end
+
+function discretize(pp::ProductProcess; kwargs...)
+    return discretize(DiscreteMarkovProcess, pp; kwargs...)
+end
 
 
 # compatibility names

--- a/test/test_product.jl
+++ b/test/test_product.jl
@@ -1,0 +1,39 @@
+using Gadfly
+import Dolo
+using AxisArrays
+
+path = Dolo.pkg_path
+
+
+model = Dolo.yaml_import(
+        joinpath(path,
+         "examples","models",
+         "rbc_catastrophe.yaml")
+)
+
+Dolo.discretize(Dolo.MarkovChain, model.exogenous)
+
+dp = Dolo.discretize(model.exogenous)
+
+sol = Dolo.time_iteration(model, dp)
+
+sim = Dolo.simulate(model, sol.dr, dp, T=100)
+sim
+plot(y=sim[Axis{:N}(1), Axis{:V}(:k)],Geom.line)
+
+plot(y=sim[Axis{:N}(1), Axis{:V}(:mc_process)],Geom.line)
+
+dp
+
+
+
+
+
+
+
+
+
+
+
+
+Gadfly.plot(y=)


### PR DESCRIPTION
The basic example works but this is not finished.
One can now do: 
```
exogenous: !Product
    p1: !VAR1
         rho: 0.8
         Sigma: [[0.001]]
    p2: !MarkovChain
        values: [[0.0],[0.1]]
        transitions: [[0.97, 0.03], [0.1, 0.9]]
```
A few remarks:
- This works with two processes but one should be able to do it recursively. 
- All components are discretized as markov chains. In the future we could play with other combinations.
- I would have preferred to use a yaml list with possibly more than two elements but it is not possible with current yaml parsing.
