### PR TITLE
Adding an error message in grid.jl. Fixing a bug in discretize(mvn::MvNormal).

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -125,6 +125,10 @@ function get_calibration(model::ASModel)
     end
     # so far _calib is a symbolic calibration
     calibration = solve_triangular_system(_calib)
+    # if  isempty(calibration)
+    #   msg = string("bla")
+    #   error(msg)
+    # end
     symbols = get_symbols(model)
     return ModelCalibration(calibration, symbols)
 end
@@ -150,6 +154,11 @@ function get_grid(model::ASModel; options=Dict())
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = CartesianGrid(domain.min, domain.max, orders)
+        if length(orders)!=length(model.calibration[:exogenous])
+            msg = string("Check the dimension of the matrix given in the yaml file, section: options-grid-orders. ",
+                         "Expected to be of dimension $([1, length(model.calibration[:exogenous])])")
+            error(msg)
+        end
     elseif grid_dict[:tag] == :Smolyak
         mu = grid_dict[:mu]
         grid = SmolyakGrid(domain.min, domain.max, mu)

--- a/src/model.jl
+++ b/src/model.jl
@@ -125,10 +125,6 @@ function get_calibration(model::ASModel)
     end
     # so far _calib is a symbolic calibration
     calibration = solve_triangular_system(_calib)
-    # if  isempty(calibration)
-    #   msg = string("bla")
-    #   error(msg)
-    # end
     symbols = get_symbols(model)
     return ModelCalibration(calibration, symbols)
 end

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -90,7 +90,7 @@ MvNormal(sigma::Float64) = MvNormal(reshape([sigma], 1, 1))
 
 function discretize(mvn::MvNormal)
     n = fill(5, size(mvn.mu))
-    x, w = QE.qnwnorm(n, mvn.mu, mvn.Sigma)
+    x, w = QE.qnwnorm(n, mvn.mu, diagm(vec(mvn.Sigma)))
     DiscretizedIIDProcess(x, w)
 end
 
@@ -211,7 +211,7 @@ function discretize(::Type{DiscreteMarkovProcess}, var::VAR1; N::Int=3)
 
     # it would be good to have a special type of VAR1 process
     # which has a scalar autoregressive term
-    R = var.R
+    R =  var.R
     d = size(R, 1)
     ρ = R[1, 1]
     @assert maximum(abs, R-eye(d)*ρ)<1e-16


### PR DESCRIPTION
About the bug: 
A model with 2 iid shocks. The yaml file excepts Sigma of exogenous process as 2-element Array{Array{Int64,1},1}:
```
exogenous: !Normal
       Sigma: [[sig_a^2], [sig_b^2]]
```

But discretizing model.exogenous it raises an error, because: `ishermitian(A) || non_hermitian_error("chol")`. I fixed it, however I wonder whether it is more logical to change the yaml file to accept: 
```
exogenous: !Normal
       Sigma: [[sig_a^2 0]; [0 sig_b^2]]
```