### PR TITLE
Azh/error msg

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,3 +10,4 @@ QuantEcon 0.10.1
 Distributions
 Compat 0.17.0
 Dolang
+StringDistances

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -25,6 +25,7 @@ import Distributions
 
 # Simulation/presentation
 using AxisArrays
+using StringDistances
 
 # Compat across julia versions
 using Compat; import Compat: String, view, @__dot__

--- a/src/model.jl
+++ b/src/model.jl
@@ -63,17 +63,18 @@ function get_equations(model::ASModel)
 
     # prep equations: parse to Expr
     _eqs = OrderedDict{Symbol,Vector{Expr}}()
-    for k in keys(recipe[:specs])
-        if k in keys(eqs)
-            # we handle these separately
-            (k in [:arbitrage,]) && continue
-            these_eq = get(eqs, (k), [])
-            # verify that we have at least 1 equation if section is required
-            if !get(recipe[:specs][k], :optional, false)
-                length(these_eq) == 0 && error("equation section $k required")
-            end
-            # finally pass in the expressions
-            _eqs[k] = Expr[_to_expr(eq) for eq in these_eq]
+    for k in Dolo.keys(eqs)
+        if !(k in Dolo.keys(recipe[:specs]))
+             ii=0
+             dist = zeros(length(Dolo.keys(recipe[:specs])))
+             for kk in Dolo.keys(recipe[:specs])
+               ii+=1
+               dist[ii]=compare(Hamming(), string(kk), string(k))
+             end
+             kk = collect(keys(Dolo.keys(recipe[:specs]).dict))[findmax(dist)[2]]
+             msg = string("You are using a wrong name for a sub-section title.`$(k)` is not accepted. ",
+                          "Maybe you meant `$(kk)`?")
+             error(msg)
         end
     end
     # handle the arbitrage, arbitrage_exp, controls_lb, and controls_ub

--- a/src/model.jl
+++ b/src/model.jl
@@ -125,6 +125,10 @@ function get_calibration(model::ASModel)
     end
     # so far _calib is a symbolic calibration
     calibration = solve_triangular_system(_calib)
+    # if  isempty(calibration)
+    #   msg = string("bla")
+    #   error(msg)
+    # end
     symbols = get_symbols(model)
     return ModelCalibration(calibration, symbols)
 end
@@ -150,6 +154,11 @@ function get_grid(model::ASModel; options=Dict())
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = CartesianGrid(domain.min, domain.max, orders)
+        if length(orders)!=length(model.calibration[:exogenous])
+            msg = string("Check the dimension of the matrix given in the yaml file, section: options-grid-orders. ",
+                         "Expected to be of dimension $([1, length(model.calibration[:exogenous])])")
+            error(msg)
+        end
     elseif grid_dict[:tag] == :Smolyak
         mu = grid_dict[:mu]
         grid = SmolyakGrid(domain.min, domain.max, mu)

--- a/src/model.jl
+++ b/src/model.jl
@@ -63,20 +63,30 @@ function get_equations(model::ASModel)
 
     # prep equations: parse to Expr
     _eqs = OrderedDict{Symbol,Vector{Expr}}()
+    # for k in Dolo.keys(recipe[:specs])
     for k in Dolo.keys(eqs)
-        if !(k in Dolo.keys(recipe[:specs]))
-             ii=0
-             dist = zeros(length(Dolo.keys(recipe[:specs])))
-             for kk in Dolo.keys(recipe[:specs])
-               ii+=1
-               dist[ii]=compare(Hamming(), string(kk), string(k))
-             end
-             kk = collect(keys(Dolo.keys(recipe[:specs]).dict))[findmax(dist)[2]]
-             msg = string("You are using a wrong name for a sub-section title.`$(k)` is not accepted. ",
-                          "Maybe you meant `$(kk)`?")
-             error(msg)
-        end
+      if !(k in Dolo.keys(recipe[:specs]))
+           ii=0
+           dist = zeros(length(Dolo.keys(recipe[:specs])))
+           for kk in Dolo.keys(recipe[:specs])
+             ii+=1
+             dist[ii]=compare(Hamming(), string(kk), string(k))
+           end
+           kk = collect(keys(Dolo.keys(recipe[:specs]).dict))[findmax(dist)[2]]
+           msg = string("You are using a wrong name for a sub-section title.`$(k)` is not accepted. ",
+                        "Maybe you meant `$(kk)`?")
+           error(msg)
+      end
+      (k in [:arbitrage,]) && continue
+      these_eq = get(eqs, (k), [])
+      # verify that we have at least 1 equation if section is required
+      if !get(recipe[:specs][k], :optional, false)
+          length(these_eq) == 0 && error("equation section $k required")
+      end
+      # finally pass in the expressions
+      _eqs[k] = Expr[_to_expr(eq) for eq in these_eq]
     end
+    # end
     # handle the arbitrage, arbitrage_exp, controls_lb, and controls_ub
     if haskey(recipe[:specs], :arbitrage) && (:arbitrage in keys(eqs))
         c_lb, c_ub, arb = _handle_arbitrage(eqs[:arbitrage],
@@ -151,7 +161,7 @@ function get_grid(model::ASModel; options=Dict())
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = CartesianGrid(domain.min, domain.max, orders)
-        if !(typeof(model.exogenous)<:Dolo.DiscreteMarkovProcess) && length(model.calibration[:exogenous])>1 && length(orders)!=length(model.calibration[:exogenous])
+        if !(typeof(model.exogenous)<:Union{Dolo.DiscreteMarkovProcess,Dolo.ProductProcess} ) && length(model.calibration[:exogenous])>1 && length(orders)!=length(model.calibration[:exogenous])
             msg = string("Check the dimension of the matrix given in the yaml file, section: options-grid-orders. ",
                          "Expected to be of dimension $([1, length(model.calibration[:exogenous])])")
             error(msg)

--- a/src/model.jl
+++ b/src/model.jl
@@ -125,10 +125,6 @@ function get_calibration(model::ASModel)
     end
     # so far _calib is a symbolic calibration
     calibration = solve_triangular_system(_calib)
-    # if  isempty(calibration)
-    #   msg = string("bla")
-    #   error(msg)
-    # end
     symbols = get_symbols(model)
     return ModelCalibration(calibration, symbols)
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -151,7 +151,7 @@ function get_grid(model::ASModel; options=Dict())
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = CartesianGrid(domain.min, domain.max, orders)
-        if length(model.calibration[:exogenous])>1 && length(orders)!=length(model.calibration[:exogenous])
+        if !(typeof(model.exogenous)<:Dolo.DiscreteMarkovProcess) && length(model.calibration[:exogenous])>1 && length(orders)!=length(model.calibration[:exogenous])
             msg = string("Check the dimension of the matrix given in the yaml file, section: options-grid-orders. ",
                          "Expected to be of dimension $([1, length(model.calibration[:exogenous])])")
             error(msg)

--- a/src/model.jl
+++ b/src/model.jl
@@ -150,7 +150,7 @@ function get_grid(model::ASModel; options=Dict())
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = CartesianGrid(domain.min, domain.max, orders)
-        if length(orders)!=length(model.calibration[:exogenous])
+        if length(model.calibration[:exogenous])>1 && length(orders)!=length(model.calibration[:exogenous])
             msg = string("Check the dimension of the matrix given in the yaml file, section: options-grid-orders. ",
                          "Expected to be of dimension $([1, length(model.calibration[:exogenous])])")
             error(msg)

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -90,7 +90,7 @@ MvNormal(sigma::Float64) = MvNormal(reshape([sigma], 1, 1))
 
 function discretize(mvn::MvNormal)
     n = fill(5, size(mvn.mu))
-    x, w = QE.qnwnorm(n, mvn.mu, diagm(vec(mvn.Sigma)))
+    x, w = QE.qnwnorm(n, mvn.mu, mvn.Sigma)
     DiscretizedIIDProcess(x, w)
 end
 

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -90,7 +90,7 @@ MvNormal(sigma::Float64) = MvNormal(reshape([sigma], 1, 1))
 
 function discretize(mvn::MvNormal)
     n = fill(5, size(mvn.mu))
-    x, w = QE.qnwnorm(n, mvn.mu, mvn.Sigma)
+    x, w = QE.qnwnorm(n, mvn.mu, diagm(vec(mvn.Sigma)))
     DiscretizedIIDProcess(x, w)
 end
 
@@ -211,7 +211,7 @@ function discretize(::Type{DiscreteMarkovProcess}, var::VAR1; N::Int=3)
 
     # it would be good to have a special type of VAR1 process
     # which has a scalar autoregressive term
-    R = var.R
+    R =  var.R
     d = size(R, 1)
     ρ = R[1, 1]
     @assert maximum(abs, R-eye(d)*ρ)<1e-16


### PR DESCRIPTION
Adding error messages. One when equation sub-sections are misspelled. Another one is about a matrix of grid points given in section: options-grid-orders.