### PR TITLE
FIX: set_calibration was not working.

### DIFF
--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -42,7 +42,7 @@ export arbitrage, transition, auxiliary, value, expectation,
        evaluate_definitions
 
        # dolo functions
-export yaml_import, eval_with, evaluate, evaluate!, model_type, name, filename, id, features
+export yaml_import, eval_with, evaluate, evaluate!, model_type, name, filename, id, features, set_calibration!
 
 export time_iteration, improved_time_iteration, value_iteration, residuals,
         response, simulate, perfect_foresight, time_iteration_direct, find_deterministic_equilibrium, perturbate

--- a/src/model.jl
+++ b/src/model.jl
@@ -270,6 +270,22 @@ function set_calibration!(model::Model, key::Symbol, value::Union{Real,Expr, Sym
     model.calibration
 end
 
+function set_calibration!(model::Model, values)
+    for (key,value) in values
+        model.data[:calibration][key] = value
+    end
+    model.calibration = get_calibration(model)
+    model.exogenous = get_exogenous(model)
+    model.domain = get_domain(model)
+    # model.options = get_options(model) # we don't substitute calib here
+    model.grid = get_grid(model)
+    model.calibration
+end
+
+function set_calibration!(model::Model; kwargs...)
+    set_calibration!(model, kwargs)
+end
+
 """
 Imports the model from a yaml file specified by the `url` input
 parameter, and returns the corresponding `Dolo` model object.

--- a/src/model.jl
+++ b/src/model.jl
@@ -270,7 +270,7 @@ function set_calibration!(model::Model, key::Symbol, value::Union{Real,Expr, Sym
     model.calibration
 end
 
-function set_calibration!(model::Model, values)
+function set_calibration!{T}(model::Model, values::Associative{Symbol,T})
     for (key,value) in values
         model.data[:calibration][key] = value
     end
@@ -283,7 +283,7 @@ function set_calibration!(model::Model, values)
 end
 
 function set_calibration!(model::Model; kwargs...)
-    set_calibration!(model, kwargs)
+    set_calibration!(model, Dict(kwargs))
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -186,7 +186,7 @@ function get_exogenous(model::ASModel)
     return exogenous
 end
 
-function set_calibration(model::ASModel, key::Symbol, value::Union{Real,Expr, Symbol})
+function set_calibration!(model::ASModel, key::Symbol, value::Union{Real,Expr, Symbol})
     model.data[:calibration][key] = value
 end
 
@@ -260,6 +260,15 @@ function Model(url::AbstractString; print_code=false)
     return Model{id}(data; print_code=print_code, filename=fname)
 end
 
+function set_calibration!(model::Model, key::Symbol, value::Union{Real,Expr, Symbol})
+    model.data[:calibration][key] = value
+    model.calibration = get_calibration(model)
+    model.exogenous = get_exogenous(model)
+    model.domain = get_domain(model)
+    # model.options = get_options(model) # we don't substitute calib here
+    model.grid = get_grid(model)
+    model.calibration
+end
 
 """
 Imports the model from a yaml file specified by the `url` input

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,10 @@ using Dolo, DataStructures, Base.Test
 
 tests = length(ARGS) > 0 ? ARGS : ["model_types",
                                    "model_import",
-                                   "test_algos",
-                                   "test_perfect_foresight",
-                                   "test_features",
+                                   "test_calibration",
+                                #    "test_algos",
+                                #    "test_perfect_foresight",
+                                #    "test_features",
                                    "test_minilang"]
 
 for t in tests

--- a/test/test_calibration.jl
+++ b/test/test_calibration.jl
@@ -1,0 +1,55 @@
+@testset "Testing model calibration" begin
+
+    path = joinpath(Dolo.pkg_path, "examples", "models")
+    model = Dolo.yaml_import(joinpath(path, "rbc_dtcc_iid.yaml"))
+
+    calib_0 = copy( model.calibration.flat )
+
+    # check one value
+    beta = model.calibration.flat[:beta]
+    delta = model.calibration.flat[:delta]
+    rk = model.calibration.flat[:rk]
+    k0 = model.calibration[:states][2]
+    assert(beta==0.99)
+    assert(rk==1/beta-1+delta)
+    assert( abs(k0-9.35498)<1e-5 )
+
+
+    # check calibrations are still correct after modifications
+    Dolo.set_calibration!(model, :beta, 0.98)
+    beta = model.calibration.flat[:beta]
+    delta = model.calibration.flat[:delta]
+    rk = model.calibration.flat[:rk]
+    k0 = model.calibration[:states][2]
+    assert(beta==0.98)
+    assert(rk==1/beta-1+delta)
+    assert( abs(k0-6.37024)<1e-4 )
+
+    # can we change many parameters at the same time?
+    Dolo.set_calibration!(model, Dict(:beta=>0.97, :i=>:(delta*k-0.01)))
+    rk = model.calibration.flat[:rk]
+    beta = model.calibration.flat[:beta]
+    delta = model.calibration.flat[:delta]
+    k0 = model.calibration[:states][2]
+    i0 = model.calibration[:controls][2]
+    assert(beta==0.97)
+    assert(rk==1/beta-1+delta)
+    assert( i0==delta*k0-0.01 )
+
+    # put everything back to original values
+    set_calibration!(model, beta=0.99, i=:(delta*k))
+    # check one value
+    beta = model.calibration.flat[:beta]
+    delta = model.calibration.flat[:delta]
+    rk = model.calibration.flat[:rk]
+    k0 = model.calibration[:states][2]
+    i0 = model.calibration[:controls][2]
+    assert(beta==0.99)
+    assert(rk==1/beta-1+delta)
+    assert( abs(k0-9.35498)<1e-5 )
+    assert( i0==delta*k0 )
+
+
+
+
+end


### PR DESCRIPTION
@sglyon, @azheng25 : this fixes two things:

- rename `set_calibration` to `set_calibration!` which seems to make more sense
- older, experimental, version used to change only the symbolic structure (in model.data["calibration"]). That was pretty useless. Now we update all calibrated values, (grid, domain, etc... not options).

Not that we still change one parameter at a time.