### PR TITLE
Revert "MacroTools min version 0.3.3"

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-MacroTools 0.3.3
+MacroTools
 YAML 0.2.1
 DataStructures
 AxisArrays


### PR DESCRIPTION
This reverts commit 49922393733c9078c658f9e6f6609cdb309d8a84 from #64.

I misread this due to the misformatted "0.3.3" MacroTools tag showing
up out of order on github, missing the "v" prefix. Pkg.test("Dolo")
actually works against any MacroTools release on Julia 0.5. Some of
the MacroTools tags don't work on Julia 0.6, but that's MacroTools'
issue and could be addressed with julia upper bounds on those tags.