### PR TITLE
Ezgioz/improve pf

### DIFF
--- a/src/algos/perfect_foresight.jl
+++ b/src/algos/perfect_foresight.jl
@@ -119,7 +119,7 @@ function perfect_foresight(model, exo::AbstractMatrix{Float64}; T=200, verbose=t
 end
 
 # Constructs the matrix exo given a dictionary exo and calls the original method
-function perfect_foresight(model, exo::Dict{Symbol,Array{Float64,1}}; kwargs... )
+function perfect_foresight(model, exo::Dict{Symbol,Array{Real,1}}; kwargs... )
 
   n_e = length(model.symbols[:exogenous])
   T_e = maximum(length(e) for e in values(exo))

--- a/src/algos/perfect_foresight.jl
+++ b/src/algos/perfect_foresight.jl
@@ -119,8 +119,8 @@ function perfect_foresight(model, exo::AbstractMatrix{Float64}; T=200, verbose=t
 end
 
 # Constructs the matrix exo given a dictionary exo and calls the original method
-function perfect_foresight(model, exo::Dict{Symbol,Array{Float64,1}}; kwargs... )
-
+function perfect_foresight(model, exo::Dict{}; kwargs... )
+  convert(Dict{Symbol,Array{Float64,1}}, exo)
   n_e = length(model.symbols[:exogenous])
   T_e = maximum(length(e) for e in values(exo))
   exo_new = zeros(T_e,n_e)

--- a/src/algos/perfect_foresight.jl
+++ b/src/algos/perfect_foresight.jl
@@ -118,8 +118,8 @@ function perfect_foresight(model, exo::AbstractMatrix{Float64}; T=200, verbose=t
 
 end
 
-
-function perfect_foresight(model, exo::Dict{Symbol,Any}; kwargs... )
+# Constructs the matrix exo given a dictionary exo and calls the original method
+function perfect_foresight(model, exo::Dict{Symbol,Array{Float64,1}}; kwargs... )
 
   n_e = length(model.symbols[:exogenous])
   T_e = maximum(length(e) for e in values(exo))

--- a/src/algos/perfect_foresight.jl
+++ b/src/algos/perfect_foresight.jl
@@ -117,3 +117,27 @@ function perfect_foresight(model, exo::AbstractMatrix{Float64}; T=200, verbose=t
     return AxisArray(resp', Axis{:V}(headers) ,Axis{:T}(0:T-1))
 
 end
+
+
+function perfect_foresight(model, exo::Dict{Symbol,Any}; kwargs... )
+
+  n_e = length(model.symbols[:exogenous])
+  T_e = maximum(length(e) for e in values(exo))
+  exo_new = zeros(T_e,n_e)
+
+    for key in keys(exo)
+      ind = find(model.symbols[:exogenous] .== key)
+      T_key = length(exo[key])
+      exo_new[1:T_key,ind] = exo[key]
+
+      for t=(T_key+1):T_e
+        exo_new[t,ind] =  exo[key][end]
+      end
+
+    end
+
+  exo = exo_new
+
+  return perfect_foresight(model, exo; kwargs... )
+
+end

--- a/src/algos/perfect_foresight.jl
+++ b/src/algos/perfect_foresight.jl
@@ -119,7 +119,7 @@ function perfect_foresight(model, exo::AbstractMatrix{Float64}; T=200, verbose=t
 end
 
 # Constructs the matrix exo given a dictionary exo and calls the original method
-function perfect_foresight(model, exo::Dict{Symbol,Array{Real,1}}; kwargs... )
+function perfect_foresight(model, exo::Dict{Symbol,Array{Float64,1}}; kwargs... )
 
   n_e = length(model.symbols[:exogenous])
   T_e = maximum(length(e) for e in values(exo))

--- a/test/test_perfect_foresight.jl
+++ b/test/test_perfect_foresight.jl
@@ -1,5 +1,30 @@
 import Dolo
 
+path = Dolo.pkg_path
+
+@testset "testing perfect_foresight" begin
+
+    fn = joinpath(path, "examples", "models", "rbc_dtcc_ar1.yaml")
+
+    model = Dolo.yaml_import(fn)
+
+    # we must define the series for exogenous shocks
+    n_e = length(model.symbols[:exogenous])
+
+    T_e = 5
+    exo = zeros(T_e, n_e)
+    exo[1,:] = [0.00]  # this is used to determine initial steady-state of the model
+    exo[2,:] = [0.01]
+    exo[3,:] = [0.02]
+    exo[4,:] = [0.03]
+    exo[5,:] = [0.04]  # this is used to determine final steady-state
+
+    @time df = Dolo.perfect_foresight(model, exo, T=20)
+
+    @test true
+
+end
+
 
 # Second method: Define a dictionary with shocks
 # Compare the results with the previous method
@@ -74,4 +99,4 @@ exo = Dict( :xi =>  [0, 0, 0, 0, 0], :z =>  [0.00, 0.01, 0.02, 0.03, 0.04])
 @time df_2dict_d = Dolo.perfect_foresight(model, exo, T=20)
 if df_2matrix == df_2dict_d
   println("df is the same")
-end 
+end

--- a/test/test_perfect_foresight.jl
+++ b/test/test_perfect_foresight.jl
@@ -24,3 +24,71 @@ path = Dolo.pkg_path
     @test true
 
 end
+
+# Second method: Define a dictionary with shocks
+# Compare the results with the previous method
+
+path = Dolo.pkg_path
+fn = joinpath(path, "examples", "models", "rbc_dtcc_ar1.yaml");
+
+model = Dolo.yaml_import(fn);
+
+n_e = length(model.symbols[:exogenous])
+T_e = 5
+exo = zeros(T_e, n_e)
+exo[1,:] = [0.00]  # this is used to determine initial steady-state of the model
+exo[2,:] = [0.01]
+exo[3,:] = [0.02]
+exo[4,:] = [0.03]
+exo[5,:] = [0.04]
+@time df_1matrix = Dolo.perfect_foresight(model, exo, T=20)
+
+
+exo = Dict(:z =>  [0.00, 0.01, 0.02, 0.03, 0.04])
+@time df_1dict = Dolo.perfect_foresight(model, exo, T=20)
+
+if df_1dict == df_1matrix
+  println("df is the same")
+end
+
+
+# Two shocks
+fn = joinpath(path, "examples", "models", "rbc_catastrophe.yaml");
+
+model = Dolo.yaml_import(fn)
+
+n_e = length(model.symbols[:exogenous])
+T_e = 5
+exo = zeros(T_e, n_e)
+exo[1,:] = [0.00, 0.00]  # this is used to determine initial steady-state of the model
+exo[2,:] = [0.01, 0.00]
+exo[3,:] = [0.02, 0.00]
+exo[4,:] = [0.03, 0.00]
+exo[5,:] = [0.04, 0.00]
+@time  df_2matrix = Dolo.perfect_foresight(model, exo, T=20)
+
+
+exo = Dict(:z =>  [0.00, 0.01, 0.02, 0.03, 0.04], :xi =>  [0.00, 0.00, 0.00, 0.00, 0.00])
+@time  df_2dict_a = Dolo.perfect_foresight(model, exo, T=20)
+
+if df_2matrix == df_2dict_a
+  println("df is the same")
+end
+
+# or
+
+exo = Dict(:z =>  [0.00, 0.01, 0.02, 0.03, 0.04])
+@time df_2dict_b = Dolo.perfect_foresight(model, exo, T=20)
+
+if df_2matrix == df_2dict_b
+  println("df is the same")
+end
+
+
+#or order changed
+exo = Dict( :xi =>  [0.00, 0.00, 0.00, 0.00, 0.00], :z =>  [0.00, 0.01, 0.02, 0.03, 0.04])
+@time df_2dict_c = Dolo.perfect_foresight(model, exo, T=20)
+
+if df_2matrix == df_2dict_c
+  println("df is the same")
+end 

--- a/test/test_perfect_foresight.jl
+++ b/test/test_perfect_foresight.jl
@@ -1,29 +1,5 @@
 import Dolo
 
-path = Dolo.pkg_path
-
-@testset "testing perfect_foresight" begin
-
-    fn = joinpath(path, "examples", "models", "rbc_dtcc_ar1.yaml")
-
-    model = Dolo.yaml_import(fn)
-
-    # we must define the series for exogenous shocks
-    n_e = length(model.symbols[:exogenous])
-
-    T_e = 5
-    exo = zeros(T_e, n_e)
-    exo[1,:] = [0.00]  # this is used to determine initial steady-state of the model
-    exo[2,:] = [0.01]
-    exo[3,:] = [0.02]
-    exo[4,:] = [0.03]
-    exo[5,:] = [0.04]  # this is used to determine final steady-state
-
-    @time df = Dolo.perfect_foresight(model, exo, T=20)
-
-    @test true
-
-end
 
 # Second method: Define a dictionary with shocks
 # Compare the results with the previous method
@@ -43,8 +19,7 @@ exo[4,:] = [0.03]
 exo[5,:] = [0.04]
 @time df_1matrix = Dolo.perfect_foresight(model, exo, T=20)
 
-
-exo = Dict(:z =>  [0.00, 0.01, 0.02, 0.03, 0.04])
+exo = Dict(:z =>  [0, 0.01, 0.02, 0.03, 0.04])
 @time df_1dict = Dolo.perfect_foresight(model, exo, T=20)
 
 if df_1dict == df_1matrix
@@ -90,5 +65,13 @@ exo = Dict( :xi =>  [0.00, 0.00, 0.00, 0.00, 0.00], :z =>  [0.00, 0.01, 0.02, 0.
 @time df_2dict_c = Dolo.perfect_foresight(model, exo, T=20)
 
 if df_2matrix == df_2dict_c
+  println("df is the same")
+end
+
+#or not defined as Float64
+exo = Dict( :xi =>  [0, 0, 0, 0, 0], :z =>  [0.00, 0.01, 0.02, 0.03, 0.04])
+
+@time df_2dict_d = Dolo.perfect_foresight(model, exo, T=20)
+if df_2matrix == df_2dict_d
   println("df is the same")
 end 


### PR DESCRIPTION
Method defined as:
function perfect_foresight(model, exo::Dict{Symbol,Array{Float64,1}}; kwargs... )

Given a dictionary exo, constructs the matrix exo and calls the original method. Test file tests if all the results are the same.

- One shock
matrix vs dictionary 

- Two shocks
matrix vs dictionaries defined differently (different order for shocks or zero shock not explicitly provided)

Instead of  exo::Dict{Symbol,Array{Float64,1}}, tried a more general definition for dictionary type but 

> exo::Dict{Symbol,Array{Real,1}}
 or
> exo::Dict{Symbol,Any}

doesn't work.

So we expect Float64 as input. 

This may cause errors if user defines a zero shock as [0,0,0,0] for instance. Shall we define this argument as exo::Dict{} then?

