### PR TITLE
Albop/update interp

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -11,3 +11,4 @@ Distributions
 Compat 0.17.0
 Dolang
 StringDistances
+StaticArrays

--- a/examples/models/rbc_dtcc_ar1.yaml
+++ b/examples/models/rbc_dtcc_ar1.yaml
@@ -83,4 +83,4 @@ exogenous: !VAR1
 
 options:
     grid: !Cartesian
-        orders: [5]
+        orders: [59]

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -66,8 +66,10 @@ id{ID}(::AbstractModel{ID}) = ID
 @compat Value{n} = SVector{n,Float64}
 @compat ListOfPoints{d} = Vector{Point{d}}
 @compat ListOfValues{n} = Vector{Value{n}}
-vector_to_matrix(v::Vector) = Matrix(v')
-vector_to_matrix(v::RowVector) = Matrix(v)
+
+vector_to_matrix(v::Vector) = Matrix(vec(v)')
+# vector_to_matrix(v::Vector) = Matrix(v')
+# vector_to_matrix(v::RowVector) = Matrix(v)
 
 # recursively make all keys at any layer of nesting a symbol
 # included here instead of util.jl so we can call it on RECIPES below

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -60,6 +60,15 @@ export AbstractModel, AbstractDecisionRule
 
 id{ID}(::AbstractModel{ID}) = ID
 
+
+# conventions for list of points
+Point{d} = SVector{d,Float64}
+Value{n} = SVector{n,Float64}
+ListOfPoints{d} = Vector{Point{d}}
+ListOfValues{n} = Vector{Value{n}}
+vector_to_matrix(v::Vector) = Matrix(v')
+vector_to_matrix(v::RowVector) = Matrix(v)
+
 # recursively make all keys at any layer of nesting a symbol
 # included here instead of util.jl so we can call it on RECIPES below
 _symbol_dict(x) = x

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -67,7 +67,7 @@ id{ID}(::AbstractModel{ID}) = ID
 @compat ListOfPoints{d} = Vector{Point{d}}
 @compat ListOfValues{n} = Vector{Value{n}}
 
-vector_to_matrix(v::Vector) = Matrix(vec(v)')
+vector_to_matrix(v) = Matrix(vec(v)')
 # vector_to_matrix(v::Vector) = Matrix(v')
 # vector_to_matrix(v::RowVector) = Matrix(v)
 

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -6,6 +6,7 @@ module Dolo
 using DataStructures: OrderedDict
 import YAML; using YAML: load_file, load
 using Requests: get
+using StaticArrays
 
 # solvers
 using NLsolve
@@ -79,6 +80,8 @@ end
 
 include("numeric/splines/splines.jl")
 import .splines
+import .splines: eval_UC_spline, eval_UC_spline!, prefilter!
+
 
 include("numeric/newton.jl")
 include("numeric/grids.jl")

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -62,10 +62,10 @@ id{ID}(::AbstractModel{ID}) = ID
 
 
 # conventions for list of points
-Point{d} = SVector{d,Float64}
-Value{n} = SVector{n,Float64}
-ListOfPoints{d} = Vector{Point{d}}
-ListOfValues{n} = Vector{Value{n}}
+@compat Point{d} = SVector{d,Float64}
+@compat Value{n} = SVector{n,Float64}
+@compat ListOfPoints{d} = Vector{Point{d}}
+@compat ListOfValues{n} = Vector{Value{n}}
 vector_to_matrix(v::Vector) = Matrix(v')
 vector_to_matrix(v::RowVector) = Matrix(v)
 

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -31,14 +31,9 @@ function euler_residuals(model, dprocess::AbstractDiscretizedProcess, s, x::Arra
             M = inode(dprocess, i, j)
             w = iweight(dprocess, i, j)
             # Update the states
-            for n in 1:N
-                S[n, :] = Dolo.transition(model, m, s[n, :], x[i][n, :], M, p)
-            end
-
+            S[:,:] = Dolo.transition(model, m, s, x[i], M, p)
             X = dr(i, j, S)
-            for n in 1:N
-                res[i][n, :] += w*Dolo.arbitrage(model, m, s[n, :], x[i][n, :], M, S[n, :], X[n, :], p)
-            end
+            res[i][:,:] += w*Dolo.arbitrage(model, m, s, x[i], M, S, X, p)
         end
     end
     return res

--- a/src/algos/time_iteration_direct.jl
+++ b/src/algos/time_iteration_direct.jl
@@ -77,20 +77,16 @@ function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess,
                 M = inode(dprocess, i, j)
                 w = iweight(dprocess, i, j)
                 # Update the states
-                for n in 1:N
-                    S[n, :] = Dolo.transition(model, m, s[n, :], x0[i][n, :], M, p)
-                end
+
+                S[:,:] = Dolo.transition(model, m, s, x0[i], M, p)
                 # interpolate controles conditional states of tomorrow
                 X = dr(i, j, S)
-                # Compute expectations as a weited average of the exo states w_j
-                for n in 1:N
-                    E_f[i][n, :] += w*Dolo.expectation(model, M, S[n, :], X[n, :], p)
-                end
+                # Compute expectations as a weighted average of the exo states w_j
+                E_f[i][:,:] += w*Dolo.expectation(model, M, S, X, p)
+
             end
             # compute controles of tomorrow
-            for n in 1:N
-                x1[i][n, :] = Dolo.direct_response(model, m, s[n, :], E_f[i][n, :], p)
-            end
+            x1[i][:] = Dolo.direct_response(model, m, s, E_f[i], p)
         end
 
         err = 0.0

--- a/src/numeric/decision_rules.jl
+++ b/src/numeric/decision_rules.jl
@@ -42,7 +42,6 @@ end
 (dr::BiTaylorExpansion)(m::AbstractMatrix, s::AbstractVector) = vcat([(dr(m[i, :], s))' for i=1:size(m, 1) ]...)
 (dr::BiTaylorExpansion)(m::AbstractVector, s::AbstractMatrix) = vcat([(dr(m, s[i, :]))' for i=1:size(s, 1) ]...)
 (dr::BiTaylorExpansion)(m::AbstractMatrix, s::AbstractMatrix) = vcat([(dr(m[i, :], s[i, :]))' for i=1:size(m, 1) ]...)
-(dr::BiTaylorExpansion)(i::Int64, s::AbstractMatrix) = dr(s)
 
 
 #####

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -268,7 +268,7 @@ function simulate(var::VAR1, N::Int, T::Int, x0::Vector{Float64};
     end
 
     if irf
-        E[:, 1, :] = repmat(e0,1,N)
+        E[:, 1, :] = repmat(e0,1,T)
     end
 
     # Initial conditions

--- a/src/numeric/splines/cubic_prefilter.jl
+++ b/src/numeric/splines/cubic_prefilter.jl
@@ -1,0 +1,160 @@
+function solve_coefficients!(
+            bands::AbstractMatrix{Float64},
+            bb::AbstractVector{T},
+            coefs::AbstractVector{T}
+    ) where T
+
+    M = size(coefs,1) - 2
+
+    # Solve interpolating equations
+    # First and last rows are different
+
+    bands[1, 2] /= bands[1, 1]
+    bands[1, 3] /= bands[1, 1]
+    bb[1] /= bands[1, 1]
+    bands[1, 1] = 1.0
+    bands[2, 2] -= bands[2, 1] * bands[1, 2]
+    bands[2, 3] -= bands[2, 1] * bands[1, 3]
+    bb[2] -= bands[2, 1] * bb[1]
+    bands[1, 1] = 0.0
+    bands[2, 3] /= bands[2, 2]
+    bb[2] /= bands[2, 2]
+    bands[2, 2] = 1.0
+
+    # Now do rows 2 through M+1
+    for row = 3:(M+1)
+        bands[row, 2] -= bands[row, 1] * bands[row - 1, 3]
+        bb[row] -= bands[row, 1] * bb[row - 1]
+        bands[row, 3] /= bands[row, 2]
+        bb[row] /= bands[row, 2]
+        bands[row, 1] = 0.0
+        bands[row, 2] = 1.0
+    end
+    # Do last row
+    bands[M + 2, 2] -= bands[M + 2, 1] * bands[M, 3]
+    bb[M + 2] -= bands[M + 2, 1] * bb[M]
+    bands[M + 2, 3] -= bands[M + 2, 2] * bands[M + 1, 3]
+    bb[M + 2] -= bands[M + 2, 2] * bb[M + 1]
+    bb[M + 2] /= bands[M + 2, 3]
+    bands[M + 2, 3] = 1.0
+
+    coefs[M + 2] = bb[M + 2]
+    # Now back substitute up
+    # for row in (M+1):2
+    for ii in 1:M
+        row = M+2 - ii
+        coefs[row] = bb[row] - bands[row, 3] * coefs[row + 1]
+    end
+    # Finish with first row
+    coefs[1] = bb[1] - bands[1, 2] * coefs[2] - bands[1, 3] * coefs[3]
+
+end
+
+function fill_bands!(M::Int, bands::AbstractMatrix, bb::AbstractVector{T}, data::AbstractVector{T}) where T
+
+    # boundary conditions
+    bands[1, 1] = 1.0
+    bands[1, 2] = -2.0
+    bands[1, 3] = 1.0
+    bands[M+2, 1] = 1.0
+    bands[M+2, 2] = -2.0
+    bands[M+2, 3] = 1.0
+
+    bands[2:end-1,1] = 1.0/6.0
+    bands[2:end-1,2] = 2.0/3.0
+    bands[2:end-1,3] = 1.0/6.0
+
+    bb[:] = data[:]
+    bb[1] = zero(T)
+    bb[M+2] = zero(T)
+
+end
+
+function prefilter!(data::AbstractVector{T}) where T
+
+    # data is 1d array of length M
+    # data is 1d array of length M+2
+    M = length(data) - 2
+    bands = zeros(M+2, 3)
+    bb = zeros(T, M+2)
+    fill_bands!(M, bands, bb, data)
+    prefilter!(data, bands, bb)
+
+end
+
+function prefilter!(data, bands, bb)
+
+    M = length(data) - 2
+    fill_bands!(M, bands, bb, data)
+    solve_coefficients!(bands, bb, data)
+
+end
+
+
+
+function prefilter!(data::Array{T,1}) where T
+    M = size(data,1)-2
+    bands = zeros(M+2,3)
+    bb = zeros(T,M+2)
+    fill_bands!(M, bands, bb, data)
+    prefilter!(data, bands, bb)
+end
+
+function prefilter!(data::Array{T,2}) where T
+    I,J = size(data)
+
+    M = J-2
+    bands = zeros(M+2,3)
+    bb = zeros(T,M+2)
+    for i=1:I
+            dat = view(data, i, :)
+            # prefilter!(dat)
+            fill_bands!(M, bands, bb, dat)
+            prefilter!(dat, bands, bb)
+    end
+    M = I-2
+    bands = zeros(M+2, 3)
+    bb = zeros(T,M+2)
+    for j=1:J
+        dat = view(data, :, j)
+        # prefilter!(dat)
+        #
+        fill_bands!(M, bands, bb, dat)
+        prefilter!(dat, bands, bb)
+    end
+end
+
+function prefilter!(data::Array{T,3}) where T
+    I,J,K = size(data)
+
+    M = K-2
+    bands = zeros(M+2,3)
+    bb = zeros(T,M+2)
+    for i=1:I
+        for j=1:J
+            dat = view(data, i,j, :)
+            fill_bands!(M, bands, bb, dat)
+            prefilter!(dat, bands, bb)
+        end
+    end
+    M = J-2
+    bands = zeros(M+2, 3)
+    bb = zeros(T,M+2)
+    for i=1:I
+        for k=1:K
+            dat = view(data, i,:, k)
+            fill_bands!(M, bands, bb, dat)
+            prefilter!(dat, bands, bb)
+        end
+    end
+    M = I-2
+    bands = zeros(M+2, 3)
+    bb = zeros(T,M+2)
+    for j=1:J
+        for k=1:K
+            dat = view(data, :, j,k)
+            fill_bands!(M, bands, bb, dat)
+            prefilter!(dat, bands, bb)
+        end
+    end
+end

--- a/src/numeric/splines/splines.jl
+++ b/src/numeric/splines/splines.jl
@@ -1,10 +1,13 @@
 module splines
 
 export filter_coeffs, interpolant_cspline, filter_coeffs
-export eval_UC_spline, eval_UC_spline_G, eval_UC_multi_spline, eval_UC_multi_spline!
+export eval_UC_spline, eval_UC_spline!
+export prefilter!
 
 include("csplines.jl")
 include("splines_filter.jl")
+include("cubic_prefilter.jl")
+
 
 function interpolant_cspline(a, b, orders, V)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Dolo, DataStructures, Base.Test
 tests = length(ARGS) > 0 ? ARGS : ["model_types",
                                    "model_import",
                                    "test_calibration",
-                                #    "test_algos",
+                                   "test_algos",
                                 #    "test_perfect_foresight",
                                 #    "test_features",
                                    "test_minilang"]


### PR DESCRIPTION
This PR is a preliminary step towards using static arrays as discussed in #79 . It introduces two types `Point{d}={SArray{Float64,d}}` and `ListOfPoints{d} = Vector{SArray{Float64,d}}`.
I did the two following changes:
- update the included interpolation routine, so as to operate on static arrays (both prefiltering and filtering steps)
- update decision rules to *internally* use these static arrays. That is, they are defined to operate on list-of-points, with compatibility calls for one row-per-observation matrices. 
- removed a fair bit of memory allocation, most of it coming from the compability calls.
Performance gains are between 30% and 50% on my machine.
