### PR TITLE
Azh/generator

### DIFF
--- a/src/algos/ITI_additional.jl
+++ b/src/algos/ITI_additional.jl
@@ -39,23 +39,24 @@ function euler_residuals(model, s::AbstractArray, x::Array{Array{Float64,2},1}, 
        m=(hcat([e' for e in m_prep]...))'
 
        for I_ms in 1:n_mst
-         for (w, M_prep, j) in get_integration_nodes(dprocess,i)
-          # M_prep = [inode(dprocess, i_ms, I_ms)' for i in 1:N_s]
-          # w = iweight(dprocess, i_ms, I_ms)
-          M=(hcat([e' for e in M_prep]...))'
-          # Update the states
-          S = transition(model, m, s, x[i_ms], M, parms)
-          X = dr(i_ms, I_ms, S)
+           for (w, M_prep, j) in get_integration_nodes(dprocess,i)
+               # M_prep = [inode(dprocess, i_ms, I_ms)' for i in 1:N_s]
+               # w = iweight(dprocess, i_ms, I_ms)
+               M=(hcat([e' for e in M_prep]...))'
+               # Update the states
+               S = transition(model, m, s, x[i_ms], M, parms)
+               X = dr(i_ms, I_ms, S)
 
-          if with_jres==true
-              ff = SerialDifferentiableFunction(u->arbitrage(model, m,s,x[i_ms],M,S,u,parms))
-              rr, rr_XM = ff(X)
-              jres[i_ms,I_ms,:,:,:] = w*rr_XM
-              S_ij[i_ms,I_ms,:,:] = S
-          else
-              rr = arbitrage(model, m,s,x[i_ms],M,S,X,parms)
-          end
-          res[i_ms,:,:] += w*rr
+               if with_jres==true
+                   ff = SerialDifferentiableFunction(u->arbitrage(model, m,s,x[i_ms],M,S,u,parms))
+                   rr, rr_XM = ff(X)
+                   jres[i_ms,I_ms,:,:,:] = w*rr_XM
+                   S_ij[i_ms,I_ms,:,:] = S
+               else
+                   rr = arbitrage(model, m,s,x[i_ms],M,S,X,parms)
+               end
+               res[i_ms,:,:] += w*rr
+            end
         end
 
     end

--- a/src/algos/ITI_additional.jl
+++ b/src/algos/ITI_additional.jl
@@ -39,11 +39,12 @@ function euler_residuals(model, s::AbstractArray, x::Array{Array{Float64,2},1}, 
        m=(hcat([e' for e in m_prep]...))'
 
        for I_ms in 1:n_mst
-          M_prep = [inode(dprocess, i_ms, I_ms)' for i in 1:N_s]
+         for (w, M_prep, j) in get_integration_nodes(dprocess,i)
+          # M_prep = [inode(dprocess, i_ms, I_ms)' for i in 1:N_s]
+          # w = iweight(dprocess, i_ms, I_ms)
           M=(hcat([e' for e in M_prep]...))'
-          w = iweight(dprocess, i_ms, I_ms)
+          # Update the states
           S = transition(model, m, s, x[i_ms], M, parms)
-
           X = dr(i_ms, I_ms, S)
 
           if with_jres==true

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -1,12 +1,17 @@
 
-nodes_generator(dprocess::Dolo.AbstractDiscretizedProcess, i::Int) = Task() do
+get_integration_nodes(dprocess::Dolo.AbstractDiscretizedProcess, i::Int)=filter( x -> (x[1]!=0), ((iweight(dprocess,i,j), inode(dprocess,i,j), j) for j in n_inodes(dprocess,i)) )
+
+
+nodes_generator(dprocess::AbstractDiscretizedProcess, i::Int) = Task() do
     M= zeros(length(dprocess.values[:,2]))
     w = zeros(1)
     j=1
-    while j <= Dolo.n_inodes(dprocess, i)
-      M = Dolo.inode(dprocess, i, j)
-      w = Dolo.iweight(dprocess, i, j)
-      produce(M,w)
+    while j <= n_inodes(dprocess, i)
+      M = inode(dprocess, i, j)
+      w = iweight(dprocess, i, j)
+      if w!= 0
+           produce(w,M,j)
+      end
       j=j+1
     end
 end
@@ -47,13 +52,13 @@ function euler_residuals(model, dprocess::AbstractDiscretizedProcess, s, x::Arra
         #     X = dr(i, j, S)
         #     res[i][:,:] += w*Dolo.arbitrage(model, m, s, x[i], M, S, X, p)
         # end
-        j=1
-        for (M, w) in nodes_generator(dprocess,i)
+
+        for (w, M, j) in nodes_generator(dprocess,i)
+        # for (w, M, j) in get_integration_nodes(dprocess,i)
             # Update the states
             S[:,:] = Dolo.transition(model, m, s, x[i], M, p)
             X = dr(i, j, S)
             res[i][:,:] += w*Dolo.arbitrage(model, m, s, x[i], M, S, X, p)
-            j=j+1
         end
     end
     return res

--- a/src/algos/time_iteration.jl
+++ b/src/algos/time_iteration.jl
@@ -1,20 +1,4 @@
 
-get_integration_nodes(dprocess::Dolo.AbstractDiscretizedProcess, i::Int)=filter( x -> (x[1]!=0), ((iweight(dprocess,i,j), inode(dprocess,i,j), j) for j in n_inodes(dprocess,i)) )
-
-
-nodes_generator(dprocess::AbstractDiscretizedProcess, i::Int) = Task() do
-    M= zeros(length(dprocess.values[:,2]))
-    w = zeros(1)
-    j=1
-    while j <= n_inodes(dprocess, i)
-      M = inode(dprocess, i, j)
-      w = iweight(dprocess, i, j)
-      if w!= 0
-           produce(w,M,j)
-      end
-      j=j+1
-    end
-end
 
 """
 Computes the residuals of the arbitrage equations. The general form of the arbitrage equation is
@@ -44,17 +28,7 @@ function euler_residuals(model, dprocess::AbstractDiscretizedProcess, s, x::Arra
     # X = zeros(size(x[1]))
     for i in 1:size(res, 1)
         m = node(dprocess, i)
-        # for j in 1:n_inodes(dprocess, i)
-        #     M = inode(dprocess, i, j)
-        #     w = iweight(dprocess, i, j)
-        #     # Update the states
-        #     S[:,:] = Dolo.transition(model, m, s, x[i], M, p)
-        #     X = dr(i, j, S)
-        #     res[i][:,:] += w*Dolo.arbitrage(model, m, s, x[i], M, S, X, p)
-        # end
-
-        for (w, M, j) in nodes_generator(dprocess,i)
-        # for (w, M, j) in get_integration_nodes(dprocess,i)
+        for (w, M, j) in get_integration_nodes(dprocess,i)
             # Update the states
             S[:,:] = Dolo.transition(model, m, s, x[i], M, p)
             X = dr(i, j, S)

--- a/src/algos/time_iteration_direct.jl
+++ b/src/algos/time_iteration_direct.jl
@@ -73,11 +73,8 @@ function time_iteration_direct(model, dprocess::AbstractDiscretizedProcess,
 
         for i in 1:size(E_f, 1)
             m = node(dprocess, i)
-            for j in 1:n_inodes(dprocess, i)
-                M = inode(dprocess, i, j)
-                w = iweight(dprocess, i, j)
+            for (w, M, j) in get_integration_nodes(dprocess,i)
                 # Update the states
-
                 S[:,:] = Dolo.transition(model, m, s, x0[i], M, p)
                 # interpolate controles conditional states of tomorrow
                 X = dr(i, j, S)

--- a/src/algos/value_iteration.jl
+++ b/src/algos/value_iteration.jl
@@ -93,13 +93,10 @@ function evaluate_policy(model, dprocess::AbstractDiscretizedProcess, grid, dr;
         # Compute value function for each smooth decision rule
         for i = 1:nsd
             m = node(dprocess, i)
-            for j = 1:n_inodes(dprocess, i)
-                M = inode(dprocess, i, j)
-                w = iweight(dprocess, i, j)
+            for (w, M, j) in get_integration_nodes(dprocess,i)
                  for n=1:N
                      # Update the states
                      S = Dolo.transition(model, m, s[n, :], x[i][n, :], M, p)
-
                      # Update value function
                       E_V[i][n, :] += w*drv(i, j, S)
                  end
@@ -149,9 +146,8 @@ function update_value(model, β::Float64, dprocess, drv, i, s::Vector{Float64},
                       x0::Vector{Float64}, p::Vector{Float64})
     m = node(dprocess, i)
     E_V = 0.0
-    for j=1:n_inodes(dprocess, i)
-        M = inode(dprocess, i, j)
-        w = iweight(dprocess, i, j)
+    for (w, M, j) in get_integration_nodes(dprocess,i)
+        # Update the states
         S = Dolo.transition(model, m, s, x0, M, p)
         E_V += w*drv(i, j, S)[1]
     end

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -392,6 +392,10 @@ function AgingProcess(mu::Float64, K::Int)
 end
 
 
+get_integration_nodes(dprocess::Dolo.AbstractDiscretizedProcess, i::Int)=filter( x -> (x[1]!=0), ((iweight(dprocess,i,j), inode(dprocess,i,j), j) for j in 1:n_inodes(dprocess,i)) )
+
+
+
 # compatibility names
 const AR1 = VAR1
 const MarkovChain = DiscreteMarkovProcess

--- a/test/test_mc_ar1_simulate.jl
+++ b/test/test_mc_ar1_simulate.jl
@@ -5,8 +5,7 @@ import Dolo
 
 path = Dolo.pkg_path
 using AxisArrays
-# path2 = "https://raw.githubusercontent.com/azheng25/OLG-Examples/master"
-# filename = joinpath(path2,"Huggett1996_processes.yaml")
+
 filename = joinpath(path,"examples","models","rbc_dtcc_mc.yaml")
 model = Dolo.yaml_import(filename)
 @time dr = Dolo.time_iteration(model, verbose=true, maxit=10000)

--- a/test/test_mc_ar1_simulate.jl
+++ b/test/test_mc_ar1_simulate.jl
@@ -5,137 +5,12 @@ import Dolo
 
 path = Dolo.pkg_path
 using AxisArrays
-
-filename = joinpath(path,"examples","models","rbc_dtcc_mc.yaml")
+path2 = "https://raw.githubusercontent.com/azheng25/OLG-Examples/master"
+filename = joinpath(path2,"Huggett1996_processes.yaml")
+# filename = joinpath(path,"examples","models","rbc_dtcc_mc.yaml")
 # model = Dolo.Model(joinpath(Dolo.pkg_path, "examples", "models", "rbc_dtcc_mc.yaml"), print_code=true)
 model = Dolo.yaml_import(filename)
 @time dr = Dolo.time_iteration(model, verbose=true, maxit=10000)
-
-params = model.calibration[:parameters]
-
-driving_process = Dolo.simulate(model.exogenous, 1, 5, 1)
-N = size(driving_process, 2)
-T = size(driving_process, 1)
-epsilons = zeros(Int, N, 1, T)
-for _n in 1:N
-    epsilons[_n, 1, :] = driving_process[:, _n]
-end
-
-# calculate initial controls using decision rule
-x0 = dr.dr(epsilons[1, :, 1], model.calibration[:states])
-
-
-epsilons = permutedims(driving_process, [2, 1, 3]) # (N, ne, T)
-
-# calculate initial controls using decision rule
-x0 = dr(epsilons[1, :, 1], s0)
-
-nodes_generator(dprocess::Dolo.AbstractDiscretizedProcess, i::Int) = Task() do
-  # for x in dprocess
-    M= zeros(length(dprocess.values[:,2]))
-    w = zeros(1)
-    j=1
-    while j <= Dolo.n_inodes(dprocess, i)
-      M = Dolo.inode(dprocess, i, j)
-      w = Dolo.iweight(dprocess, i, j)
-      produce(M,w)
-      # produce(w)
-      j=j+1
-    end
-  # end
-  #
-  # for x in 1:14
-  #   produce(0)
-  # end
-end
-
-###############################################################################
-### Simulate a model with a Markov Chain
-dprocess= Dolo.discretize( model.exogenous )
-#
-# i = 1
-#
-#
-# function integration_nodes(dprocess::Dolo.AbstractDiscretizedProcess, i::Int)
-#     M= zeros(length(dprocess.values[:,2]))
-#     w = zeros(1)
-#     # produce(M)
-#     # produce(w)
-#     j=1
-#     while true
-#     # for j = 1:Dolo.n_inodes(dprocess, i)
-#         M = Dolo.inode(dprocess, i, j)
-#         w = Dolo.iweight(dprocess, i, j)
-#         produce(M,w)
-#         # produce(w)
-#     end
-#     j=j+1
-#     # end
-#     # Task(_it)
-# end
-#
-# generator =@task integration_nodes(dprocess,1)
-# Aa, Bb = consume(generator)
-# Aa
-
-i=1
-nodes_generator(dprocess::Dolo.AbstractDiscretizedProcess, i::Int) = Task() do
-  # for x in dprocess
-    M= zeros(length(dprocess.values[:,2]))
-    w = zeros(1)
-    j=1
-    while j <= Dolo.n_inodes(dprocess, i)
-      M = Dolo.inode(dprocess, i, j)
-      w = Dolo.iweight(dprocess, i, j)
-      produce(M,w)
-      # produce(w)
-      j=j+1
-    end
-  # end
-  #
-  # for x in 1:14
-  #   produce(0)
-  # end
-end
-# Mx = bit_generator(dprocess, i)
-
-j=1
-for (Mx, w) in nodes_generator(dprocess, i)
-  println(j)
-  println(Mx, w)
-  j=j+1
-  #  println(1)
-end
-sdsd
-# function integration_nodes(dprocess::Dolo.AbstractDiscretizedProcess, i::Int)
-#     M= zeros(length(dprocess.values[:,2]))
-#     w = zeros(1)
-#     produce(M)
-#     produce(w)
-#     # function _it()
-#         # for i = 1:n
-#           for j = 1:Dolo.n_inodes(dprocess, i)
-#             M = Dolo.inode(dprocess, i, j)
-#             w = Dolo.iweight(dprocess, i, j)
-#             produce(M)
-#             produce(w)
-#           end
-#     # end
-#     # Task(_it)
-# end
-# w = Dolo.iweight(dprocess, 1, 1)
-#
-# M= zeros(length(dprocess.values[:,2]))
-# w = zeros(1)
-# function _it()
-#     # for i = 1:n
-#       for j = 1:Dolo.n_inodes(dprocess, i)
-#         M = inode(dprocess, i, j)
-#         w = iweight(dprocess, i, j)
-#     end
-# end
-#
-# Task(_it)
 
 
 
@@ -169,37 +44,35 @@ for i in 1:size(res, 1)
     end
 end
 
+
 res
+
+
+
+
+
+
+
+
+get_integration_nodes(dprocess::Dolo.AbstractDiscretizedProcess, i::Int)=filter(w->(w[1]!=0),((Dolo.iweight(dprocess,i,j), Dolo.inode(dprocess,i,j), j) for j in Dolo.n_inodes(dprocess,i)) )
+
 
 for i in 1:size(res, 1)
     m = Dolo.node(dprocess, i)
-    j=1
-    for (M, w) in nodes_generator(dprocess,i)
+    for (w,M, j) in get_integration_nodes(dprocess,i)
         # Update the states
         S[:,:] = Dolo.transition(model, m, s, x[i], M, p)
         X = dr(i, j, S)
         res[i][:,:] += w*Dolo.arbitrage(model, m, s, x[i], M, S, X, p)
-        j=j+1
+        println(M)
     end
 end
-
-
 
 
 res
 
 
-s= "text"
-for x in s
-    a = Int8(x[1])
-    i = 0
-end
-
-x
-a = Int8(x[1])
-a = a >> 1
-
-
+res
 
 
 


### PR DESCRIPTION
Adding a generator that would substitute 
```
for j in n_inodes(dprocess)
    M = dprocess.inode(i)
    w = dprocess.iweight(i)
    ...
end
```
by
```
for (w, M, j) in get_integration_nodes(dprocess)
    ....
end
```
This generator is supposed to take less memory, plus it excludes the future nodes which have probability 0 from an iterations loop.