### PR TITLE
FIX: condition in options - size of order edited

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -162,9 +162,9 @@ function get_grid(model::ASModel; options=Dict())
     if grid_dict[:tag] == :Cartesian
         orders = get(grid_dict, :orders, [20 for i=1:d])
         grid = CartesianGrid{d}(domain.min, domain.max, orders)
-        if !(typeof(model.exogenous)<:Union{Dolo.DiscreteMarkovProcess,Dolo.ProductProcess} ) && length(model.calibration[:exogenous])>1 && length(orders)!=length(model.calibration[:exogenous])
+        if length(orders)!=length(model.calibration[:states])
             msg = string("Check the dimension of the matrix given in the yaml file, section: options-grid-orders. ",
-                         "Expected to be of dimension $([1, length(model.calibration[:exogenous])])")
+                         "Expected to be of dimension $([length(model.calibration[:states])])")
             error(msg)
         end
     elseif grid_dict[:tag] == :Smolyak


### PR DESCRIPTION
length(orders)!=length(model.calibration[:states])