### PR TITLE
REF: perturbate->perturb and Dolo.jl/export += tabulate

### DIFF
--- a/docs/src/algos.md
+++ b/docs/src/algos.md
@@ -144,5 +144,5 @@ find_deterministic_equilibrium
 ```
 
 ```@docs
-perturbate
+perturb
 ```

--- a/src/Dolo.jl
+++ b/src/Dolo.jl
@@ -60,7 +60,7 @@ export arbitrage, transition, auxiliary, value, expectation,
 export lint, yaml_import, eval_with, evaluate, evaluate!, model_type, name, filename, id, features, set_calibration!
 
 export time_iteration, improved_time_iteration, value_iteration, residuals,
-        response, simulate, perfect_foresight, time_iteration_direct, find_deterministic_equilibrium, perturbate
+        response, simulate, perfect_foresight, time_iteration_direct, find_deterministic_equilibrium, perturb, tabulate
 
 export ModelCalibration, FlatCalibration, GroupedCalibration
 export AbstractModel, AbstractDecisionRule

--- a/src/algos/perturbation.jl
+++ b/src/algos/perturbation.jl
@@ -5,11 +5,11 @@ function get_ss_derivatives(model)
     g_diff, f_diff
 end
 
-perturbate(p::IIDExogenous) = (zeros(0), zeros(0, 0))
-perturbate(p::VAR1) = (p.mu, p.R)
+perturb(p::IIDExogenous) = (zeros(0), zeros(0, 0))
+perturb(p::VAR1) = (p.mu, p.R)
 
 type PerturbationResult
-    solution::BiTaylorExpansion
+    dr::BiTaylorExpansion
     generalized_eigenvalues::Vector
     stable::Bool     # biggest e.v. lam of solution is < 1
     determined::Bool # next eigenvalue is > lam + epsilon (MOD solution well defined)
@@ -27,7 +27,7 @@ end
 
 blanchard_kahn(fos::PerturbationResult) = fos.stable && fos.unique
 
-function perturbate_first_order(g_s, g_x, f_s, f_x, f_S, f_X)
+function perturb_first_order(g_s, g_x, f_s, f_x, f_S, f_X)
 
     eigtol = 1.0+1e-6
 
@@ -78,7 +78,7 @@ function get_gf_derivatives(model::AbstractModel)
     _f_m, _f_s, _f_x, _f_M, _f_S, _f_X = f_diff
     _g_m, _g_s, _g_x, _g_M = g_diff
 
-    (M, R) = perturbate(model.exogenous)
+    (M, R) = perturb(model.exogenous)
 
     f_x = _f_x
     f_X = _f_X
@@ -103,12 +103,12 @@ end
 """
 TBD
 """
-function perturbate(model::Model)
+function perturb(model::Model)
 
     g_s, g_x, f_s, f_x, f_S, f_X = get_gf_derivatives(model)
     nx = size(g_x, 2)
 
-    (M, R) = perturbate(model.exogenous)
+    (M, R) = perturb(model.exogenous)
     _m, _s, x, p = model.calibration[:exogenous, :states, :controls, :parameters]
 
     if size(R, 1)>0
@@ -117,7 +117,7 @@ function perturbate(model::Model)
         s = _s
     end
 
-    C, genvals = perturbate_first_order(g_s, g_x, f_s, f_x, f_S, f_X)
+    C, genvals = perturb_first_order(g_s, g_x, f_s, f_x, f_S, f_X)
     sort!(genvals)
 
     if size(R, 1)>0

--- a/test/test_algos.jl
+++ b/test/test_algos.jl
@@ -58,7 +58,7 @@ path = Dolo.pkg_path
         fn = joinpath(path, "examples", "models", "rbc_iid.yaml")
         model = Dolo.yaml_import(fn)
 
-        @time dr = Dolo.perturbate(model)
+        @time dr = Dolo.perturb(model)
 
         drc = Dolo.ConstantDecisionRule(model.calibration[:controls])
 
@@ -110,7 +110,7 @@ path = Dolo.pkg_path
         model = Dolo.yaml_import(fn)
         dp = Dolo.discretize(model.exogenous)
 
-        @time dr = Dolo.perturbate(model)
+        @time dr = Dolo.perturb(model)
         @time tid_res = Dolo.time_iteration_direct(model; maxit=20, verbose=true)
         @time ti_res = Dolo.time_iteration(model, tid_res.dr; maxit=20, verbose=false)
         @time iti_res = Dolo.improved_time_iteration(model; maxit=20, verbose=false)


### PR DESCRIPTION
Not much here but: 
- `perturbate` becomes `perturb` as somebody told me `perturbate` means something different in english. @sglyon : can you confirm it's better like that ?
- export `tabulate`
- all results object have a `res.dr` field instead of `res.solution`, like the other result objects. Thanks @vandalm for pointing this out.