### PR TITLE
Deprecating functions

### DIFF
--- a/src/algos/simulation.jl
+++ b/src/algos/simulation.jl
@@ -271,7 +271,7 @@ function response(model::AbstractModel,  dr::AbstractDecisionRule,
 
     response(model,  dr; s0=s0, e1=e1, T=T)
 end
-@deprecate response(model::AbstractModel,  dr::AbstractDecisionRule,s0::AbstractVector, e1::AbstractVector; T::Int=40) response(model::AbstractModel,  dr::AbstractDecisionRule; s0::AbstractVector, e1::AbstractVector, T::Int=40)
+@deprecate response(model::AbstractModel,  dr::AbstractDecisionRule,s0::AbstractVector, e1::AbstractVector; T::Int=40) response(model,  dr; s0=s0, e1=e1, T=T)
 
 function response(model::AbstractModel,  dr::AbstractDecisionRule,
                   e1::AbstractVector; T::Int=40)

--- a/src/numeric/processes.jl
+++ b/src/numeric/processes.jl
@@ -144,7 +144,7 @@ end
 function simulate(mvn::MvNormal, N::Integer, T::Int, e0::Vector{Float64}; stochastic::Bool=true)
     simulate(mvn, e0; N=N, T=T, stochastic=stochastic)
 end
-@deprecate simulate(mvn::MvNormal, N::Integer, T::Int, e0::Vector{Float64}; stochastic::Bool=true) simulate(mvn::MvNormal, e0::Vector{Float64}; N::Integer, T::Int, stochastic::Bool=true)
+@deprecate simulate(mvn::MvNormal, N::Integer, T::Int, e0::Vector{Float64}; stochastic::Bool=true) simulate(mvn, e0; N=N, T=T, stochastic=stochastic)
 
 
 function simulate(mvn::MvNormal; N::Integer, T::Int, stochastic::Bool=true)
@@ -154,7 +154,7 @@ end
 function simulate(mvn::MvNormal, N::Integer, T::Int; stochastic::Bool=true)
     simulate(mvn, N, T, mvn.mu; stochastic=stochastic)
 end
-@deprecate simulate(mvn::MvNormal, N::Integer, T::Int; stochastic::Bool=true) simulate(mvn::MvNormal; N::Integer, T::Int, stochastic::Bool=true)
+@deprecate simulate(mvn::MvNormal, N::Integer, T::Int; stochastic::Bool=true) simulate(mvn; N=N, T=T, stochastic=stochastic)
 
 function response(mvn::MvNormal, e1::AbstractVector; T::Int=40)
     d = length(mvn.mu)
@@ -173,7 +173,7 @@ end
 function simulate(process::DiscreteMarkovProcess, N::Int, T::Int, i0::Int)
     simulate(process; N=N, T=T, i0=i0)
 end
-@deprecate simulate(process::DiscreteMarkovProcess, N::Int, T::Int, i0::Int) simulate(process::DiscreteMarkovProcess; N::Int, T::Int, i0::Int)
+@deprecate simulate(process::DiscreteMarkovProcess, N::Int, T::Int, i0::Int) simulate(process; N=N, T=T, i0=i0)
 
 function simulate(process::DiscreteMarkovProcess, m0::AbstractVector{Float64}; N::Int, T::Int)
     # try to find index in process.values. IF we do, then simulate using
@@ -190,7 +190,7 @@ end
 function simulate(process::DiscreteMarkovProcess, N::Int, T::Int, m0::AbstractVector{Float64})
     simulate(process, m0; N=N, T=T)
 end
-@deprecate simulate(process::DiscreteMarkovProcess, N::Int, T::Int, m0::AbstractVector{Float64}) simulate(process::DiscreteMarkovProcess, m0::AbstractVector{Float64}; N::Int, T::Int)
+@deprecate simulate(process::DiscreteMarkovProcess, N::Int, T::Int, m0::AbstractVector{Float64}) simulate(process, m0; N=N, T=T)
 
 function simulate_values(process::DiscreteMarkovProcess; N::Int, T::Int, i0::Int)
     inds = simulate(process; N=N, T=T, i0=i0)
@@ -205,7 +205,7 @@ end
 function simulate_values(process::DiscreteMarkovProcess, N::Int, T::Int, i0::Int)
     simulate_values(process; N=N, T=T, i0=i0)
 end
-@deprecate simulate_values(process::DiscreteMarkovProcess, N::Int, T::Int, i0::Int) simulate_values(process::DiscreteMarkovProcess; N::Int, T::Int, i0::Int)
+@deprecate simulate_values(process::DiscreteMarkovProcess, N::Int, T::Int, i0::Int) simulate_values(process; N=N, T=T, i0=i0)
 
 # VAR 1
 
@@ -342,7 +342,7 @@ function simulate(var::VAR1, N::Int, T::Int, x0::Vector{Float64};
 
     simulate(var, x0; N=N, T=T, stochastic=stochastic, irf=irf, e0=e0)
 end
-@deprecate simulate(var::VAR1, N::Int, T::Int, x0::Vector{Float64}; stochastic::Bool=true, irf::Bool=false, e0::Vector{Float64}=zeros(0)) simulate(var::VAR1, x0::Vector{Float64}; N::Int, T::Int, stochastic::Bool=true, irf::Bool=false, e0::Vector{Float64}=zeros(0))
+@deprecate simulate(var::VAR1, N::Int, T::Int, x0::Vector{Float64}; stochastic::Bool=true, irf::Bool=false, e0::Vector{Float64}=zeros(0)) simulate(var, x0; N=N, T=T, stochastic=stochastic, irf=irf, e0=e0)
 
 function simulate(var::VAR1; N::Int, T::Int, kwargs...)
     return simulate(var, var.mu; N=N, T=T, kwargs...)
@@ -351,7 +351,7 @@ end
 function simulate(var::VAR1, N::Int, T::Int; kwargs...)
     return simulate(var; N=N, T=T, kwargs...)
 end
-@deprecate simulate(var::VAR1, N::Int, T::Int; kwargs...) simulate(var::VAR1; N::Int, T::Int, kwargs...)
+@deprecate simulate(var::VAR1, N::Int, T::Int; kwargs...) simulate(var; N=N, T=T, kwargs...)
 
 function response(var::VAR1, x0::AbstractVector, e1::AbstractVector; T::Int=40)
     simulate(var, x0; N=1, T=T, stochastic=false, irf=true, e0=e1)[1, :, :]
@@ -360,7 +360,6 @@ end
 function response(var::VAR1, e1::AbstractVector; T::Int=40)
     simulate(var; N=1, T=T, stochastic=false, irf=true, e0=e1)[1, :, :]
 end
-@deprecate response(var::VAR1, e1::AbstractVector; T::Int=40) response(var::VAR1, x0::AbstractVector, e1::AbstractVector; T::Int=40)
 
 function response(var::VAR1, x0::AbstractVector, index_s::Int; T::Int=40)
     e1 = zeros(size(var.mu, 1))


### PR DESCRIPTION
This commit aims at labelling as deprecated the functions simulate and response (from simulation.jl and processes.jl) when another version with more precise kwargs exists.